### PR TITLE
Revamp Bitbucket snippet commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ atlas pr checkout 123
 
 # Snippets
 atlas snippet list
-atlas snippet create --title "My snippet" -f file.go
-atlas snippet view abc123 --contents
+atlas snippet create --title "My snippet" file.go
+atlas snippet view abc123
+atlas snippet edit abc123 file.go
+atlas snippet clone abc123
 ```
 
 **Flags:** `--json` for structured output, `--no-cache` to bypass cache, `-v` for verbose.

--- a/SPEC.md
+++ b/SPEC.md
@@ -55,11 +55,13 @@ atlas config verify  # calls /user endpoint to verify auth works
 atlas pr list [--repo <repo>] [--all] [--state <state>] [--author <author>] [--reviewer <reviewer>]
 atlas pr view <id|branch> [--repo <repo>] [--comments] [--all] [--json]
 atlas pr checkout <id|branch> [--repo <repo>]
-atlas snippet list [--workspace <workspace>]
-atlas snippet view <id> [--contents]
-atlas snippet create --title <title> -f <file> [-f <file>...]
-atlas snippet update <id> [-f <file>...] [-r <file>...]
-atlas snippet delete <id>
+atlas snippet list [--workspace <workspace>] [--role <role>] [--public|--private] [-L <limit>]
+atlas snippet view [<id|url>] [--filename <file>] [--files] [--raw] [--web] [--json]
+atlas snippet create [<file>... | -] --title <title> [--filename <file>] [--public] [--json]
+atlas snippet edit <id|url> [<filename>] [--title <title>] [--add <file>] [--remove <file>]
+atlas snippet rename <id|url> <old-filename> <new-filename>
+atlas snippet clone <id|url> [<directory>] [--protocol ssh|https] [-- <gitflags>...]
+atlas snippet delete [<id|url>] [--yes]
 atlas config set <key> [<value>]
 atlas config get <key> [--verbose]
 atlas config verify
@@ -258,37 +260,74 @@ Status only (no attribution for who completed).
 
 ### List
 
-`atlas snippet list` shows user's own snippets (not all workspace snippets).
+`atlas snippet list` shows snippets for the configured workspace.
+
+- `-L, --limit <n>`: Maximum snippets to fetch (default 10)
+- `--role owner|contributor|member`: Filter snippets by Bitbucket role
+- `--public`: Show only public snippets
+- `--private`: Show only private snippets
+- `--json`: Emit structured output
 
 ### View
 
-`atlas snippet view <id>` shows snippet metadata by default.
+`atlas snippet view <id|url>` displays snippet file contents by default.
 
-Add `--contents` flag to display file contents.
+- Uses `bat` as the pager when available, then `less`, then stdout
+- `-f, --filename <file>`: Display a single file
+- `--files`: List file names only
+- `-r, --raw`: Print raw contents without paging
+- `-w, --web`: Open the snippet in a browser
+- `--json`: Emit metadata and file contents as structured output
 
 ### Create
 
 ```bash
-atlas snippet create --title "Auth helpers" -f src/auth.go -f src/auth_test.go
+atlas snippet create --title "Auth helpers" src/auth.go src/auth_test.go
+cat src/auth.go | atlas snippet create --title "Auth helper" --filename auth.go
 ```
 
-- Requires `-f` flags (no stdin support)
-- `--private` flag (default): visible to workspace members only
+- Files are positional
+- `-` or piped input reads from standard input
+- Snippets are private by default; `--public` lists the snippet publicly
 
-### Update
+### Edit
 
 ```bash
-atlas snippet update <id> -f src/auth.go -r old_file.go
+atlas snippet edit <id|url> auth.go
+atlas snippet edit <id|url> --title "Auth helpers"
+atlas snippet edit <id|url> --add src/auth.go --remove old_file.go
 ```
 
-- `-f <file>`: Add or update files (merge behavior)
-- `-r <file>`: Remove files from snippet
+- With no add/remove/title flags, Atlas opens the selected snippet file in `$VISUAL` or `$EDITOR`
+- If no filename is provided for a multi-file snippet, Atlas prompts for a file in interactive terminals
+- `-a, --add <file>`: Add or replace a snippet file from a local file
+- `-r, --remove <file>`: Remove a file from the snippet
+
+### Rename
+
+```bash
+atlas snippet rename <id|url> old_file.go new_file.go
+```
+
+Renames by fetching the old file content, adding it under the new filename, and removing the old filename.
+
+### Clone
+
+```bash
+atlas snippet clone <id|url>
+atlas snippet clone <id|url> ./local-dir -- --depth 1
+atlas snippet clone <id|url> --protocol https
+```
+
+Clone uses SSH by default. Use `--protocol https` when SSH is not configured.
 
 ### Delete
 
 ```bash
-atlas snippet delete <id>
+atlas snippet delete <id|url> --yes
 ```
+
+Without `--yes`, Atlas asks for confirmation in interactive terminals.
 
 ---
 
@@ -501,16 +540,19 @@ Retry with backoff based on `--retry` flag, then fail with actionable suggestion
 
 ### Phase 11: Snippets
 
-**Goal**: Create, view, update, and delete Bitbucket snippets.
+**Goal**: Create, view, edit, clone, rename, and delete Bitbucket snippets.
 
 **Deliverables**:
-- `atlas snippet list` shows user's own snippets
-- `atlas snippet view <id>` displays metadata (add `--contents` for files)
-- `atlas snippet create --title <title> -f <file> [-f <file>...]` creates snippet
-- `atlas snippet update <id> -f <file>` adds/updates files (merge behavior)
-- `atlas snippet update <id> -r <file>` removes files
-- `atlas snippet delete <id>` removes snippet
-- `--private` flag (default): visible to workspace members only
+- `atlas snippet list` supports limit, visibility filters, role filters, and JSON output
+- `atlas snippet view [<id|url>]` displays file contents through `bat`/`less` when available
+- `atlas snippet create [<file>... | -] --title <title>` creates private snippets by default
+- `atlas snippet edit <id|url>` opens snippet files in `$VISUAL` or `$EDITOR`
+- `atlas snippet edit <id|url> --add <file>` adds/updates files
+- `atlas snippet edit <id|url> --remove <file>` removes files
+- `atlas snippet rename <id|url> <old> <new>` renames snippet files
+- `atlas snippet clone <id|url>` clones via SSH by default
+- `atlas snippet delete [<id|url>]` removes snippet
+- `--public` opt-in: snippets are private by default
 
 **Endpoints needed**:
 - `GET /snippets/{workspace}` - list snippets
@@ -520,7 +562,7 @@ Retry with backoff based on `--retry` flag, then fail with actionable suggestion
 - `PUT /snippets/{workspace}/{id}` - update snippet
 - `DELETE /snippets/{workspace}/{id}` - delete snippet
 
-**Testable outcome**: `atlas snippet create --title test -f README.md` creates a snippet and returns its ID.
+**Testable outcome**: `atlas snippet create --title test README.md` creates a private snippet and returns its ID.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -55,7 +55,7 @@ atlas config verify  # calls /user endpoint to verify auth works
 atlas pr list [--repo <repo>] [--all] [--state <state>] [--author <author>] [--reviewer <reviewer>]
 atlas pr view <id|branch> [--repo <repo>] [--comments] [--all] [--json]
 atlas pr checkout <id|branch> [--repo <repo>]
-atlas snippet list [--workspace <workspace>] [--role <role>] [--public|--private] [-L <limit>]
+atlas snippet list [--workspace <workspace>] [--role <role>] [--public|--private] [-L <limit>] [--json]
 atlas snippet view [<id|url>] [--filename <file>] [--files] [--raw] [--web] [--json]
 atlas snippet create [<file>... | -] --title <title> [--filename <file>] [--public] [--json]
 atlas snippet edit <id|url> [<filename>] [--title <title>] [--add <file>] [--remove <file>]

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -434,9 +434,53 @@ func extractNextPath(nextURL string) string {
 	return ""
 }
 
-func (c *Client) ListSnippets(workspace string) ([]Snippet, error) {
+func escapePathPreservingSlashes(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("snippet filename cannot be empty")
+	}
+	if strings.HasPrefix(path, "/") {
+		return "", fmt.Errorf("snippet filename %q cannot be absolute", path)
+	}
+
+	parts := strings.Split(path, "/")
+	for i, part := range parts {
+		if part == "" {
+			return "", fmt.Errorf("snippet filename %q cannot contain empty path segments", path)
+		}
+		if part == "." || part == ".." {
+			return "", fmt.Errorf("snippet filename %q cannot contain dot segments", path)
+		}
+		parts[i] = url.PathEscape(part)
+	}
+	return strings.Join(parts, "/"), nil
+}
+
+type SnippetListOptions struct {
+	Limit int
+	Role  string
+}
+
+func snippetListPath(workspace string, opts *SnippetListOptions) string {
+	values := url.Values{}
+	if opts != nil {
+		if opts.Limit > 0 {
+			values.Set("pagelen", strconv.Itoa(opts.Limit))
+		}
+		if opts.Role != "" {
+			values.Set("role", opts.Role)
+		}
+	}
+
+	path := fmt.Sprintf("/snippets/%s", url.PathEscape(workspace))
+	if encoded := values.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	return path
+}
+
+func (c *Client) ListSnippets(workspace string, opts *SnippetListOptions) ([]Snippet, error) {
 	var snippets []Snippet
-	path := fmt.Sprintf("/snippets/%s", workspace)
+	path := snippetListPath(workspace, opts)
 
 	for path != "" {
 		data, err := c.get(path)
@@ -450,6 +494,9 @@ func (c *Client) ListSnippets(workspace string) ([]Snippet, error) {
 		}
 
 		snippets = append(snippets, page.Values...)
+		if opts != nil && opts.Limit > 0 && len(snippets) >= opts.Limit {
+			return snippets[:opts.Limit], nil
+		}
 		path = extractNextPath(page.Next)
 	}
 
@@ -457,7 +504,7 @@ func (c *Client) ListSnippets(workspace string) ([]Snippet, error) {
 }
 
 func (c *Client) GetSnippet(workspace, id string) (*Snippet, error) {
-	path := fmt.Sprintf("/snippets/%s/%s", workspace, id)
+	path := fmt.Sprintf("/snippets/%s/%s", url.PathEscape(workspace), url.PathEscape(id))
 	data, err := c.get(path)
 	if err != nil {
 		return nil, err
@@ -472,12 +519,16 @@ func (c *Client) GetSnippet(workspace, id string) (*Snippet, error) {
 }
 
 func (c *Client) GetSnippetFileContent(workspace, id, filename string) ([]byte, error) {
-	path := fmt.Sprintf("/snippets/%s/%s/files/%s", workspace, id, filename)
+	escapedFilename, err := escapePathPreservingSlashes(filename)
+	if err != nil {
+		return nil, err
+	}
+	path := fmt.Sprintf("/snippets/%s/%s/files/%s", url.PathEscape(workspace), url.PathEscape(id), escapedFilename)
 	return c.getRaw(path)
 }
 
 func (c *Client) CreateSnippet(workspace, title string, files map[string][]byte, isPrivate bool) (*Snippet, error) {
-	url := baseURL + fmt.Sprintf("/snippets/%s", workspace)
+	url := baseURL + fmt.Sprintf("/snippets/%s", url.PathEscape(workspace))
 
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
@@ -533,11 +584,17 @@ func (c *Client) CreateSnippet(workspace, title string, files map[string][]byte,
 	return &snippet, nil
 }
 
-func (c *Client) UpdateSnippet(workspace, id string, addFiles map[string][]byte, removeFiles []string) error {
-	url := baseURL + fmt.Sprintf("/snippets/%s/%s", workspace, id)
+func (c *Client) UpdateSnippet(workspace, id, title string, addFiles map[string][]byte, removeFiles []string) error {
+	url := baseURL + fmt.Sprintf("/snippets/%s/%s", url.PathEscape(workspace), url.PathEscape(id))
 
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
+
+	if title != "" {
+		if err := writer.WriteField("title", title); err != nil {
+			return fmt.Errorf("failed to write title field: %w", err)
+		}
+	}
 
 	for filename, content := range addFiles {
 		part, err := writer.CreateFormFile("file", filename)
@@ -580,7 +637,7 @@ func (c *Client) UpdateSnippet(workspace, id string, addFiles map[string][]byte,
 }
 
 func (c *Client) DeleteSnippet(workspace, id string) error {
-	url := baseURL + fmt.Sprintf("/snippets/%s/%s", workspace, id)
+	url := baseURL + fmt.Sprintf("/snippets/%s/%s", url.PathEscape(workspace), url.PathEscape(id))
 
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -464,7 +464,11 @@ func snippetListPath(workspace string, opts *SnippetListOptions) string {
 	values := url.Values{}
 	if opts != nil {
 		if opts.Limit > 0 {
-			values.Set("pagelen", strconv.Itoa(opts.Limit))
+			pageLen := opts.Limit
+			if pageLen > 100 {
+				pageLen = 100
+			}
+			values.Set("pagelen", strconv.Itoa(pageLen))
 		}
 		if opts.Role != "" {
 			values.Set("role", opts.Role)

--- a/internal/bitbucket/snippet_test.go
+++ b/internal/bitbucket/snippet_test.go
@@ -1,0 +1,54 @@
+package bitbucket
+
+import "testing"
+
+func TestSnippetListPath(t *testing.T) {
+	t.Parallel()
+
+	got := snippetListPath("team space", &SnippetListOptions{
+		Limit: 25,
+		Role:  "owner",
+	})
+	want := "/snippets/team%20space?pagelen=25&role=owner"
+	if got != want {
+		t.Fatalf("snippetListPath() = %q, want %q", got, want)
+	}
+}
+
+func TestSnippetListPathOmitsEmptyOptions(t *testing.T) {
+	t.Parallel()
+
+	got := snippetListPath("team", nil)
+	want := "/snippets/team"
+	if got != want {
+		t.Fatalf("snippetListPath() = %q, want %q", got, want)
+	}
+}
+
+func TestEscapePathPreservingSlashes(t *testing.T) {
+	t.Parallel()
+
+	got, err := escapePathPreservingSlashes("src/auth helpers.go")
+	if err != nil {
+		t.Fatalf("escapePathPreservingSlashes() error = %v", err)
+	}
+	want := "src/auth%20helpers.go"
+	if got != want {
+		t.Fatalf("escapePathPreservingSlashes() = %q, want %q", got, want)
+	}
+}
+
+func TestEscapePathPreservingSlashesRejectsDotSegments(t *testing.T) {
+	t.Parallel()
+
+	for _, filename := range []string{"../config", "src/../config", "./config", "/config", "src//config"} {
+		filename := filename
+		t.Run(filename, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := escapePathPreservingSlashes(filename); err == nil {
+				t.Fatalf("escapePathPreservingSlashes(%q) error = nil, want error", filename)
+			}
+		})
+	}
+}

--- a/internal/bitbucket/snippet_test.go
+++ b/internal/bitbucket/snippet_test.go
@@ -15,6 +15,16 @@ func TestSnippetListPath(t *testing.T) {
 	}
 }
 
+func TestSnippetListPathClampsPageLen(t *testing.T) {
+	t.Parallel()
+
+	got := snippetListPath("team", &SnippetListOptions{Limit: 150})
+	want := "/snippets/team?pagelen=100"
+	if got != want {
+		t.Fatalf("snippetListPath() = %q, want %q", got, want)
+	}
+}
+
 func TestSnippetListPathOmitsEmptyOptions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/snippet.go
+++ b/internal/cli/snippet.go
@@ -1,59 +1,143 @@
 package cli
 
 import (
+	"bufio"
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
+	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/kabilan108/atlas/internal/bitbucket"
 	"github.com/kabilan108/atlas/internal/config"
 	"github.com/kabilan108/atlas/internal/output"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
+
+type snippetRef struct {
+	Workspace string
+	ID        string
+}
 
 func newSnippetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "snippet",
 		Short: "Work with snippets",
+		Long: `Work with Bitbucket snippets.
+
+A snippet can be supplied as an ID or a Bitbucket snippet URL.`,
 	}
 
-	cmd.AddCommand(newSnippetListCmd())
-	cmd.AddCommand(newSnippetViewCmd())
+	cmd.AddCommand(newSnippetCloneCmd())
 	cmd.AddCommand(newSnippetCreateCmd())
-	cmd.AddCommand(newSnippetUpdateCmd())
 	cmd.AddCommand(newSnippetDeleteCmd())
+	cmd.AddCommand(newSnippetEditCmd())
+	cmd.AddCommand(newSnippetListCmd())
+	cmd.AddCommand(newSnippetRenameCmd())
+	cmd.AddCommand(newSnippetViewCmd())
 
 	return cmd
 }
 
-func newSnippetListCmd() *cobra.Command {
+func newSnippetCloneCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List your snippets",
-		RunE:  runSnippetList,
+		Use:   "clone <snippet> [<directory>] [-- <gitflags>...]",
+		Short: "Clone a snippet locally",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  runSnippetClone,
 	}
 
 	cmd.Flags().String("workspace", "", "Target workspace")
+	cmd.Flags().String("protocol", "ssh", "Clone protocol: ssh or https")
+
+	return cmd
+}
+
+func runSnippetClone(cmd *cobra.Command, args []string) error {
+	dashIndex := cmd.ArgsLenAtDash()
+	snippetArgs := args
+	var gitFlags []string
+	if dashIndex >= 0 {
+		snippetArgs = args[:dashIndex]
+		gitFlags = args[dashIndex:]
+	}
+
+	if len(snippetArgs) == 0 {
+		return fmt.Errorf("snippet ID or URL is required")
+	}
+	if len(snippetArgs) > 2 {
+		return fmt.Errorf("accepts at most 2 arg(s), received %d", len(snippetArgs))
+	}
+
+	ref, err := resolveExplicitSnippetRef(cmd, snippetArgs[0])
+	if err != nil {
+		return err
+	}
+
+	protocol, _ := cmd.Flags().GetString("protocol")
+	cloneURL, err := snippetCloneURL(ref, protocol)
+	if err != nil {
+		return err
+	}
+
+	gitArgs := append([]string{"clone"}, gitFlags...)
+	gitArgs = append(gitArgs, cloneURL)
+	if len(snippetArgs) == 2 {
+		gitArgs = append(gitArgs, snippetArgs[1])
+	}
+
+	gitCmd := exec.Command("git", gitArgs...)
+	gitCmd.Stdin = os.Stdin
+	gitCmd.Stdout = os.Stdout
+	gitCmd.Stderr = os.Stderr
+	return gitCmd.Run()
+}
+
+func newSnippetListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List your snippets",
+		RunE:    runSnippetList,
+	}
+
+	cmd.Flags().String("workspace", "", "Target workspace")
+	cmd.Flags().IntP("limit", "L", 10, "Maximum number of snippets to fetch")
+	cmd.Flags().String("role", "", "Filter by role: owner, contributor, member")
+	cmd.Flags().Bool("public", false, "Show only public snippets")
+	cmd.Flags().Bool("private", false, "Show only private snippets")
 	cmd.Flags().Bool("json", false, "Output as JSON")
 
 	return cmd
 }
 
 func runSnippetList(cmd *cobra.Command, args []string) error {
-	workspaceFlag, _ := cmd.Flags().GetString("workspace")
+	workspace, err := configuredWorkspace(cmd)
+	if err != nil {
+		return err
+	}
+
+	limit, _ := cmd.Flags().GetInt("limit")
+	role, _ := cmd.Flags().GetString("role")
+	publicOnly, _ := cmd.Flags().GetBool("public")
+	privateOnly, _ := cmd.Flags().GetBool("private")
 	jsonOutput, _ := cmd.Flags().GetBool("json")
 
-	cfg, err := config.Load()
-	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+	if publicOnly && privateOnly {
+		return fmt.Errorf("--public and --private cannot be used together")
 	}
-
-	workspace := workspaceFlag
-	if workspace == "" {
-		workspace = cfg.Workspace
+	if role != "" && role != "owner" && role != "contributor" && role != "member" {
+		return fmt.Errorf("invalid role %q: expected owner, contributor, or member", role)
 	}
-	if workspace == "" {
-		return fmt.Errorf("workspace not configured. Run 'atlas config set workspace <name>' or use --workspace")
+	if limit < 1 {
+		return fmt.Errorf("--limit must be greater than 0")
 	}
 
 	client, err := bitbucket.NewClient(bitbucket.WithNoCache(noCache))
@@ -61,10 +145,19 @@ func runSnippetList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	snippets, err := client.ListSnippets(workspace)
+	listLimit := limit
+	if publicOnly || privateOnly {
+		listLimit = 0
+	}
+	snippets, err := client.ListSnippets(workspace, &bitbucket.SnippetListOptions{
+		Limit: listLimit,
+		Role:  role,
+	})
 	if err != nil {
 		return err
 	}
+	snippets = filterSnippetsByVisibility(snippets, publicOnly, privateOnly)
+	snippets = limitSnippets(snippets, limit)
 
 	if jsonOutput {
 		return output.WriteJSON(os.Stdout, snippets)
@@ -77,15 +170,11 @@ func runSnippetList(cmd *cobra.Command, args []string) error {
 
 	tw := output.NewTableWriter(os.Stdout, "ID", "Title", "Files", "Visibility", "Updated")
 	for _, s := range snippets {
-		visibility := "public"
-		if s.IsPrivate {
-			visibility = "private"
-		}
 		tw.AddRow(
 			s.ID,
 			output.Truncate(s.Title, 40),
 			fmt.Sprintf("%d", len(s.Files)),
-			visibility,
+			snippetVisibility(s),
 			output.FormatRelativeTime(s.UpdatedOn),
 		)
 	}
@@ -95,14 +184,17 @@ func runSnippetList(cmd *cobra.Command, args []string) error {
 
 func newSnippetViewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "view <id>",
+		Use:   "view [<snippet>]",
 		Short: "View a snippet",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE:  runSnippetView,
 	}
 
 	cmd.Flags().String("workspace", "", "Target workspace")
-	cmd.Flags().Bool("contents", false, "Display file contents")
+	cmd.Flags().StringP("filename", "f", "", "Display a single file from the snippet")
+	cmd.Flags().Bool("files", false, "List file names from the snippet")
+	cmd.Flags().BoolP("raw", "r", false, "Print raw instead of paged snippet contents")
+	cmd.Flags().BoolP("web", "w", false, "Open snippet in the browser")
 	cmd.Flags().Bool("json", false, "Output as JSON")
 
 	return cmd
@@ -114,22 +206,9 @@ type SnippetViewJSON struct {
 }
 
 func runSnippetView(cmd *cobra.Command, args []string) error {
-	snippetID := args[0]
-	workspaceFlag, _ := cmd.Flags().GetString("workspace")
-	showContents, _ := cmd.Flags().GetBool("contents")
-	jsonOutput, _ := cmd.Flags().GetBool("json")
-
-	cfg, err := config.Load()
+	workspace, err := optionalWorkspace(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-
-	workspace := workspaceFlag
-	if workspace == "" {
-		workspace = cfg.Workspace
-	}
-	if workspace == "" {
-		return fmt.Errorf("workspace not configured. Run 'atlas config set workspace <name>' or use --workspace")
+		return err
 	}
 
 	client, err := bitbucket.NewClient(bitbucket.WithNoCache(noCache))
@@ -137,106 +216,81 @@ func runSnippetView(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	snippet, err := client.GetSnippet(workspace, snippetID)
+	ref, err := resolveSnippetArg(client, workspace, args)
 	if err != nil {
 		return err
 	}
 
+	filename, _ := cmd.Flags().GetString("filename")
+	filesOnly, _ := cmd.Flags().GetBool("files")
+	rawOutput, _ := cmd.Flags().GetBool("raw")
+	webOutput, _ := cmd.Flags().GetBool("web")
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+
+	snippet, err := client.GetSnippet(ref.Workspace, ref.ID)
+	if err != nil {
+		return err
+	}
+
+	if webOutput {
+		return openBrowser(snippet.Links.HTML.Href)
+	}
+
 	if jsonOutput {
 		result := SnippetViewJSON{Snippet: snippet}
-		if showContents {
-			result.FileContents = make(map[string]string)
-			for filename := range snippet.Files {
-				content, err := client.GetSnippetFileContent(workspace, snippetID, filename)
-				if err != nil {
-					return fmt.Errorf("failed to fetch file %s: %w", filename, err)
-				}
-				result.FileContents[filename] = string(content)
+		if !filesOnly {
+			contents, err := snippetFileContents(client, ref, snippet, filename)
+			if err != nil {
+				return err
 			}
+			result.FileContents = contents
 		}
 		return output.WriteJSON(os.Stdout, result)
 	}
 
-	visibility := "public"
-	if snippet.IsPrivate {
-		visibility = "private"
+	if filesOnly {
+		return printSnippetFiles(snippet)
 	}
 
-	fmt.Printf("Title:      %s\n", snippet.Title)
-	fmt.Printf("ID:         %s\n", snippet.ID)
-	fmt.Printf("Owner:      %s\n", snippet.Owner.DisplayName)
-	fmt.Printf("Visibility: %s\n", visibility)
-	fmt.Printf("Created:    %s\n", output.FormatRelativeTime(snippet.CreatedOn))
-	fmt.Printf("Updated:    %s\n", output.FormatRelativeTime(snippet.UpdatedOn))
-	fmt.Printf("URL:        %s\n", snippet.Links.HTML.Href)
-	fmt.Println()
-
-	fmt.Printf("Files (%d):\n", len(snippet.Files))
-	for filename := range snippet.Files {
-		fmt.Printf("  - %s\n", filename)
+	contents, err := snippetFileContents(client, ref, snippet, filename)
+	if err != nil {
+		return err
 	}
-
-	if showContents {
-		fmt.Println()
-		for filename := range snippet.Files {
-			content, err := client.GetSnippetFileContent(workspace, snippetID, filename)
-			if err != nil {
-				return fmt.Errorf("failed to fetch file %s: %w", filename, err)
-			}
-			fmt.Printf("=== %s ===\n", filename)
-			fmt.Println(string(content))
-		}
-	}
-
-	return nil
+	return renderSnippetFiles(contents, rawOutput)
 }
 
 func newSnippetCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create a new snippet",
-		RunE:  runSnippetCreate,
+		Use:     "create [<filename>... | -]",
+		Aliases: []string{"new"},
+		Short:   "Create a new snippet",
+		RunE:    runSnippetCreate,
 	}
 
 	cmd.Flags().String("workspace", "", "Target workspace")
 	cmd.Flags().String("title", "", "Snippet title")
-	cmd.Flags().StringSliceP("file", "f", nil, "Files to include")
-	cmd.Flags().Bool("private", true, "Make snippet private (visible to workspace members only)")
+	cmd.Flags().StringP("filename", "f", "", "Filename to use when reading from standard input")
+	cmd.Flags().BoolP("public", "p", false, "List the snippet publicly")
 	cmd.Flags().Bool("json", false, "Output as JSON")
-	cmd.MarkFlagRequired("title")
-	cmd.MarkFlagRequired("file")
+	_ = cmd.MarkFlagRequired("title")
 
 	return cmd
 }
 
 func runSnippetCreate(cmd *cobra.Command, args []string) error {
-	workspaceFlag, _ := cmd.Flags().GetString("workspace")
+	workspace, err := configuredWorkspace(cmd)
+	if err != nil {
+		return err
+	}
+
 	title, _ := cmd.Flags().GetString("title")
-	files, _ := cmd.Flags().GetStringSlice("file")
-	isPrivate, _ := cmd.Flags().GetBool("private")
+	stdinFilename, _ := cmd.Flags().GetString("filename")
+	publicSnippet, _ := cmd.Flags().GetBool("public")
 	jsonOutput, _ := cmd.Flags().GetBool("json")
 
-	cfg, err := config.Load()
+	files, err := readSnippetCreateFiles(args, stdinFilename)
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-
-	workspace := workspaceFlag
-	if workspace == "" {
-		workspace = cfg.Workspace
-	}
-	if workspace == "" {
-		return fmt.Errorf("workspace not configured. Run 'atlas config set workspace <name>' or use --workspace")
-	}
-
-	fileContents := make(map[string][]byte)
-	for _, filePath := range files {
-		content, err := os.ReadFile(filePath)
-		if err != nil {
-			return fmt.Errorf("failed to read file %s: %w", filePath, err)
-		}
-		filename := filepath.Base(filePath)
-		fileContents[filename] = content
+		return err
 	}
 
 	client, err := bitbucket.NewClient(bitbucket.WithNoCache(noCache))
@@ -244,7 +298,7 @@ func runSnippetCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	snippet, err := client.CreateSnippet(workspace, title, fileContents, isPrivate)
+	snippet, err := client.CreateSnippet(workspace, title, files, !publicSnippet)
 	if err != nil {
 		return err
 	}
@@ -259,52 +313,37 @@ func runSnippetCreate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func newSnippetUpdateCmd() *cobra.Command {
+func newSnippetEditCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update <id>",
-		Short: "Update a snippet",
-		Args:  cobra.ExactArgs(1),
-		RunE:  runSnippetUpdate,
+		Use:   "edit <snippet> [<filename>]",
+		Short: "Edit a snippet",
+		Args:  cobra.RangeArgs(1, 2),
+		RunE:  runSnippetEdit,
 	}
 
 	cmd.Flags().String("workspace", "", "Target workspace")
-	cmd.Flags().StringSliceP("file", "f", nil, "Files to add or update")
-	cmd.Flags().StringSliceP("remove", "r", nil, "Files to remove")
+	cmd.Flags().String("title", "", "New title for the snippet")
+	cmd.Flags().StringP("add", "a", "", "Add a new file to the snippet")
+	cmd.Flags().StringP("filename", "f", "", "Select a file to edit")
+	cmd.Flags().StringP("remove", "r", "", "Remove a file from the snippet")
 
 	return cmd
 }
 
-func runSnippetUpdate(cmd *cobra.Command, args []string) error {
-	snippetID := args[0]
-	workspaceFlag, _ := cmd.Flags().GetString("workspace")
-	files, _ := cmd.Flags().GetStringSlice("file")
-	removeFiles, _ := cmd.Flags().GetStringSlice("remove")
-
-	if len(files) == 0 && len(removeFiles) == 0 {
-		return fmt.Errorf("at least one of --file or --remove must be specified")
-	}
-
-	cfg, err := config.Load()
+func runSnippetEdit(cmd *cobra.Command, args []string) error {
+	ref, err := resolveExplicitSnippetRef(cmd, args[0])
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
 
-	workspace := workspaceFlag
-	if workspace == "" {
-		workspace = cfg.Workspace
-	}
-	if workspace == "" {
-		return fmt.Errorf("workspace not configured. Run 'atlas config set workspace <name>' or use --workspace")
-	}
+	title, _ := cmd.Flags().GetString("title")
+	addFile, _ := cmd.Flags().GetString("add")
+	filenameFlag, _ := cmd.Flags().GetString("filename")
+	removeFile, _ := cmd.Flags().GetString("remove")
 
-	fileContents := make(map[string][]byte)
-	for _, filePath := range files {
-		content, err := os.ReadFile(filePath)
-		if err != nil {
-			return fmt.Errorf("failed to read file %s: %w", filePath, err)
-		}
-		filename := filepath.Base(filePath)
-		fileContents[filename] = content
+	filename := filenameFlag
+	if filename == "" && len(args) == 2 {
+		filename = args[1]
 	}
 
 	client, err := bitbucket.NewClient(bitbucket.WithNoCache(noCache))
@@ -312,35 +351,99 @@ func runSnippetUpdate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := client.UpdateSnippet(workspace, snippetID, fileContents, removeFiles); err != nil {
+	addFiles := make(map[string][]byte)
+	var removeFiles []string
+
+	if addFile != "" {
+		content, err := os.ReadFile(addFile)
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %w", addFile, err)
+		}
+		addFiles[snippetLocalFilename(addFile)] = content
+	}
+
+	if removeFile != "" {
+		removeFiles = append(removeFiles, removeFile)
+	}
+
+	if title == "" && addFile == "" && removeFile == "" {
+		editedName, editedContent, err := editSnippetFile(client, ref, filename)
+		if err != nil {
+			return err
+		}
+		addFiles[editedName] = editedContent
+	}
+
+	if len(addFiles) == 0 && len(removeFiles) == 0 && title == "" {
+		return fmt.Errorf("nothing to edit")
+	}
+
+	if err := client.UpdateSnippet(ref.Workspace, ref.ID, title, addFiles, removeFiles); err != nil {
 		return err
 	}
 
-	fmt.Printf("Updated snippet: %s\n", snippetID)
+	fmt.Printf("Updated snippet: %s\n", ref.ID)
+	return nil
+}
 
+func newSnippetRenameCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rename <snippet> <old-filename> <new-filename>",
+		Short: "Rename a file in a snippet",
+		Args:  cobra.ExactArgs(3),
+		RunE:  runSnippetRename,
+	}
+
+	cmd.Flags().String("workspace", "", "Target workspace")
+
+	return cmd
+}
+
+func runSnippetRename(cmd *cobra.Command, args []string) error {
+	ref, err := resolveExplicitSnippetRef(cmd, args[0])
+	if err != nil {
+		return err
+	}
+
+	oldFilename := args[1]
+	newFilename := args[2]
+
+	client, err := bitbucket.NewClient(bitbucket.WithNoCache(noCache))
+	if err != nil {
+		return err
+	}
+
+	content, err := client.GetSnippetFileContent(ref.Workspace, ref.ID, oldFilename)
+	if err != nil {
+		return fmt.Errorf("failed to fetch file %s: %w", oldFilename, err)
+	}
+
+	if err := client.UpdateSnippet(ref.Workspace, ref.ID, "", map[string][]byte{newFilename: content}, []string{oldFilename}); err != nil {
+		return err
+	}
+
+	fmt.Printf("Renamed %s to %s in snippet %s\n", oldFilename, newFilename, ref.ID)
 	return nil
 }
 
 func newSnippetDeleteCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "delete <id>",
+	cmd := &cobra.Command{
+		Use:   "delete [<snippet>]",
 		Short: "Delete a snippet",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE:  runSnippetDelete,
 	}
+
+	cmd.Flags().String("workspace", "", "Target workspace")
+	cmd.Flags().Bool("yes", false, "Confirm deletion without prompting")
+
+	return cmd
 }
 
 func runSnippetDelete(cmd *cobra.Command, args []string) error {
-	snippetID := args[0]
-
-	cfg, err := config.Load()
+	workspace, err := optionalWorkspace(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-
-	workspace := cfg.Workspace
-	if workspace == "" {
-		return fmt.Errorf("workspace not configured. Run 'atlas config set workspace <name>'")
+		return err
 	}
 
 	client, err := bitbucket.NewClient(bitbucket.WithNoCache(noCache))
@@ -348,11 +451,494 @@ func runSnippetDelete(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := client.DeleteSnippet(workspace, snippetID); err != nil {
+	ref, err := resolveSnippetArg(client, workspace, args)
+	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Deleted snippet: %s\n", snippetID)
+	yes, _ := cmd.Flags().GetBool("yes")
+	if !yes {
+		if !term.IsTerminal(int(os.Stdin.Fd())) {
+			return fmt.Errorf("refusing to delete non-interactively without --yes")
+		}
+		confirmed, err := confirmSnippetDelete(ref.ID)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			fmt.Println("Deletion cancelled.")
+			return nil
+		}
+	}
+
+	if err := client.DeleteSnippet(ref.Workspace, ref.ID); err != nil {
+		return err
+	}
+
+	fmt.Printf("Deleted snippet: %s\n", ref.ID)
 
 	return nil
+}
+
+func configuredWorkspace(cmd *cobra.Command) (string, error) {
+	workspace, err := optionalWorkspace(cmd)
+	if err != nil {
+		return "", err
+	}
+	if workspace == "" {
+		return "", fmt.Errorf("workspace not configured. Run 'atlas config set workspace <name>' or use --workspace")
+	}
+	return workspace, nil
+}
+
+func optionalWorkspace(cmd *cobra.Command) (string, error) {
+	workspaceFlag, _ := cmd.Flags().GetString("workspace")
+	if workspaceFlag != "" {
+		return workspaceFlag, nil
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return "", fmt.Errorf("failed to load config: %w", err)
+	}
+	return cfg.Workspace, nil
+}
+
+func resolveExplicitSnippetRef(cmd *cobra.Command, raw string) (snippetRef, error) {
+	workspaceFlag, _ := cmd.Flags().GetString("workspace")
+	ref, err := parseSnippetRef(raw, workspaceFlag)
+	if err == nil {
+		return ref, nil
+	}
+
+	if isURLLike(raw) || workspaceFlag != "" {
+		return snippetRef{}, err
+	}
+
+	workspace, workspaceErr := configuredWorkspace(cmd)
+	if workspaceErr != nil {
+		return snippetRef{}, workspaceErr
+	}
+	return parseSnippetRef(raw, workspace)
+}
+
+func parseSnippetRef(raw, fallbackWorkspace string) (snippetRef, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return snippetRef{}, fmt.Errorf("snippet ID or URL is required")
+	}
+
+	parsed, err := url.Parse(raw)
+	if err == nil && parsed.Host != "" {
+		parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+		switch {
+		case parsed.Host == "bitbucket.org" && len(parts) >= 3 && parts[0] == "snippets":
+			return snippetRefFromURLParts(parts[1], parts[2])
+		case parsed.Host == "bitbucket.org" && len(parts) >= 4 && parts[1] == "workspace" && parts[2] == "snippets":
+			return snippetRefFromURLParts(parts[0], parts[3])
+		case strings.HasSuffix(parsed.Host, "bitbucket.org") && len(parts) >= 4 && parts[0] == "2.0" && parts[1] == "snippets":
+			return snippetRefFromURLParts(parts[2], parts[3])
+		default:
+			return snippetRef{}, fmt.Errorf("unsupported snippet URL: %s", raw)
+		}
+	}
+
+	if fallbackWorkspace == "" {
+		return snippetRef{}, fmt.Errorf("workspace not configured. Run 'atlas config set workspace <name>' or use --workspace")
+	}
+	return snippetRef{Workspace: fallbackWorkspace, ID: raw}, nil
+}
+
+func snippetRefFromURLParts(workspacePart, idPart string) (snippetRef, error) {
+	workspace, err := url.PathUnescape(workspacePart)
+	if err != nil {
+		return snippetRef{}, fmt.Errorf("invalid snippet workspace in URL: %w", err)
+	}
+	id, err := url.PathUnescape(strings.TrimSuffix(idPart, ".git"))
+	if err != nil {
+		return snippetRef{}, fmt.Errorf("invalid snippet ID in URL: %w", err)
+	}
+	if workspace == "" || id == "" {
+		return snippetRef{}, fmt.Errorf("snippet URL must include workspace and ID")
+	}
+	return snippetRef{Workspace: workspace, ID: id}, nil
+}
+
+func isURLLike(raw string) bool {
+	parsed, err := url.Parse(raw)
+	return err == nil && parsed.Host != ""
+}
+
+func resolveSnippetArg(client *bitbucket.Client, workspace string, args []string) (snippetRef, error) {
+	if len(args) > 0 {
+		return parseSnippetRef(args[0], workspace)
+	}
+	if workspace == "" {
+		return snippetRef{}, fmt.Errorf("workspace not configured. Run 'atlas config set workspace <name>' or use --workspace")
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return snippetRef{}, fmt.Errorf("snippet ID or URL is required")
+	}
+	return selectSnippet(client, workspace)
+}
+
+func selectSnippet(client *bitbucket.Client, workspace string) (snippetRef, error) {
+	snippets, err := client.ListSnippets(workspace, &bitbucket.SnippetListOptions{Limit: 10, Role: "owner"})
+	if err != nil {
+		return snippetRef{}, err
+	}
+	if len(snippets) == 0 {
+		return snippetRef{}, fmt.Errorf("no snippets found")
+	}
+
+	for i, snippet := range snippets {
+		fmt.Fprintf(os.Stderr, "%d. %s  %s\n", i+1, snippet.ID, snippet.Title)
+	}
+	fmt.Fprint(os.Stderr, "Select snippet: ")
+
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		return snippetRef{}, err
+	}
+	choice, err := strconv.Atoi(strings.TrimSpace(line))
+	if err != nil || choice < 1 || choice > len(snippets) {
+		return snippetRef{}, fmt.Errorf("invalid selection")
+	}
+
+	return snippetRef{Workspace: workspace, ID: snippets[choice-1].ID}, nil
+}
+
+func snippetCloneURL(ref snippetRef, protocol string) (string, error) {
+	switch protocol {
+	case "ssh":
+		return fmt.Sprintf("git@bitbucket.org:snippets/%s/%s.git", ref.Workspace, ref.ID), nil
+	case "https":
+		return fmt.Sprintf("https://bitbucket.org/snippets/%s/%s.git", ref.Workspace, ref.ID), nil
+	default:
+		return "", fmt.Errorf("invalid protocol %q: expected ssh or https", protocol)
+	}
+}
+
+func readSnippetCreateFiles(args []string, stdinFilename string) (map[string][]byte, error) {
+	files := make(map[string][]byte)
+	readStdin := false
+
+	for _, arg := range args {
+		if arg == "-" {
+			readStdin = true
+			continue
+		}
+		content, err := os.ReadFile(arg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %s: %w", arg, err)
+		}
+		files[snippetLocalFilename(arg)] = content
+	}
+
+	if len(args) == 0 && !term.IsTerminal(int(os.Stdin.Fd())) {
+		readStdin = true
+	}
+
+	if readStdin {
+		if stdinFilename == "" {
+			stdinFilename = "stdin.txt"
+		}
+		content, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read standard input: %w", err)
+		}
+		files[stdinFilename] = content
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("at least one filename or - is required")
+	}
+	return files, nil
+}
+
+func snippetLocalFilename(filePath string) string {
+	cleaned := filepath.Clean(filePath)
+	if filepath.IsAbs(cleaned) {
+		return filepath.Base(cleaned)
+	}
+	return filepath.ToSlash(cleaned)
+}
+
+func filterSnippetsByVisibility(snippets []bitbucket.Snippet, publicOnly, privateOnly bool) []bitbucket.Snippet {
+	if !publicOnly && !privateOnly {
+		return snippets
+	}
+
+	filtered := make([]bitbucket.Snippet, 0, len(snippets))
+	for _, snippet := range snippets {
+		if publicOnly && !snippet.IsPrivate {
+			filtered = append(filtered, snippet)
+		}
+		if privateOnly && snippet.IsPrivate {
+			filtered = append(filtered, snippet)
+		}
+	}
+	return filtered
+}
+
+func limitSnippets(snippets []bitbucket.Snippet, limit int) []bitbucket.Snippet {
+	if limit > 0 && len(snippets) > limit {
+		return snippets[:limit]
+	}
+	return snippets
+}
+
+func snippetVisibility(snippet bitbucket.Snippet) string {
+	if snippet.IsPrivate {
+		return "private"
+	}
+	return "public"
+}
+
+func printSnippetFiles(snippet *bitbucket.Snippet) error {
+	filenames := snippetFilenames(snippet)
+	for _, filename := range filenames {
+		fmt.Println(filename)
+	}
+	return nil
+}
+
+func snippetFileContents(client *bitbucket.Client, ref snippetRef, snippet *bitbucket.Snippet, filename string) (map[string]string, error) {
+	filenames := []string{}
+	if filename != "" {
+		if _, ok := snippet.Files[filename]; !ok {
+			return nil, fmt.Errorf("file %q not found in snippet %s", filename, ref.ID)
+		}
+		filenames = append(filenames, filename)
+	} else {
+		filenames = snippetFilenames(snippet)
+	}
+
+	contents := make(map[string]string, len(filenames))
+	for _, name := range filenames {
+		content, err := client.GetSnippetFileContent(ref.Workspace, ref.ID, name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch file %s: %w", name, err)
+		}
+		contents[name] = string(content)
+	}
+	return contents, nil
+}
+
+func renderSnippetFiles(contents map[string]string, rawOutput bool) error {
+	filenames := sortedMapKeys(contents)
+	if rawOutput || !term.IsTerminal(int(os.Stdout.Fd())) {
+		for _, filename := range filenames {
+			content := contents[filename]
+			if len(contents) > 1 {
+				fmt.Printf("=== %s ===\n", filename)
+			}
+			fmt.Print(content)
+			if !strings.HasSuffix(content, "\n") {
+				fmt.Println()
+			}
+		}
+		return nil
+	}
+
+	var rendered bytes.Buffer
+	for _, filename := range filenames {
+		content := contents[filename]
+		if len(contents) > 1 {
+			fmt.Fprintf(&rendered, "=== %s ===\n", filename)
+		}
+		rendered.WriteString(sanitizeTerminalContent(content))
+		if !strings.HasSuffix(content, "\n") {
+			rendered.WriteByte('\n')
+		}
+	}
+
+	if batPath, err := exec.LookPath("bat"); err == nil {
+		args := []string{"--paging=always"}
+		if len(filenames) == 1 {
+			args = append(args, "--file-name", filenames[0])
+		}
+		return pipeToCommand(batPath, args, rendered.Bytes())
+	}
+	if lessPath, err := exec.LookPath("less"); err == nil {
+		return pipeToCommand(lessPath, nil, rendered.Bytes())
+	}
+
+	_, err := os.Stdout.Write(rendered.Bytes())
+	return err
+}
+
+func snippetFilenames(snippet *bitbucket.Snippet) []string {
+	filenames := make([]string, 0, len(snippet.Files))
+	for filename := range snippet.Files {
+		filenames = append(filenames, filename)
+	}
+	sort.Strings(filenames)
+	return filenames
+}
+
+func sortedMapKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func pipeToCommand(path string, args []string, input []byte) error {
+	cmd := exec.Command(path, args...)
+	cmd.Stdin = bytes.NewReader(input)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func openBrowser(target string) error {
+	if target == "" {
+		return fmt.Errorf("snippet does not include a web URL")
+	}
+	if opener, err := exec.LookPath("xdg-open"); err == nil {
+		return startDetached(opener, target)
+	}
+	if opener, err := exec.LookPath("open"); err == nil {
+		return startDetached(opener, target)
+	}
+	return fmt.Errorf("could not find xdg-open or open")
+}
+
+func startDetached(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return cmd.Process.Release()
+}
+
+func sanitizeTerminalContent(content string) string {
+	var b strings.Builder
+	for _, r := range content {
+		switch {
+		case r == '\n' || r == '\r' || r == '\t':
+			b.WriteRune(r)
+		case r < 0x20 || r == 0x7f:
+			fmt.Fprintf(&b, "\\x%02x", r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func editSnippetFile(client *bitbucket.Client, ref snippetRef, filename string) (string, []byte, error) {
+	snippet, err := client.GetSnippet(ref.Workspace, ref.ID)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if filename == "" {
+		switch {
+		case len(snippet.Files) == 1:
+			for name := range snippet.Files {
+				filename = name
+			}
+		case term.IsTerminal(int(os.Stdin.Fd())):
+			filename, err = selectSnippetFile(snippet)
+			if err != nil {
+				return "", nil, err
+			}
+		default:
+			return "", nil, fmt.Errorf("snippet has %d files; specify a filename", len(snippet.Files))
+		}
+	}
+
+	var existing []byte
+	if err := requireSnippetFile(snippet, ref.ID, filename); err != nil {
+		return "", nil, err
+	}
+
+	existing, err = client.GetSnippetFileContent(ref.Workspace, ref.ID, filename)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to fetch file %s: %w", filename, err)
+	}
+
+	edited, err := editBuffer(filename, existing)
+	if err != nil {
+		return "", nil, err
+	}
+	return filename, edited, nil
+}
+
+func requireSnippetFile(snippet *bitbucket.Snippet, snippetID, filename string) error {
+	if _, ok := snippet.Files[filename]; !ok {
+		return fmt.Errorf("file %q not found in snippet %s; use --add to add new files", filename, snippetID)
+	}
+	return nil
+}
+
+func selectSnippetFile(snippet *bitbucket.Snippet) (string, error) {
+	filenames := snippetFilenames(snippet)
+	for i, filename := range filenames {
+		fmt.Fprintf(os.Stderr, "%d. %s\n", i+1, filename)
+	}
+	fmt.Fprint(os.Stderr, "Select file: ")
+
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	choice, err := strconv.Atoi(strings.TrimSpace(line))
+	if err != nil || choice < 1 || choice > len(filenames) {
+		return "", fmt.Errorf("invalid selection")
+	}
+
+	return filenames[choice-1], nil
+}
+
+func editBuffer(filename string, content []byte) ([]byte, error) {
+	editor := os.Getenv("VISUAL")
+	if editor == "" {
+		editor = os.Getenv("EDITOR")
+	}
+	if editor == "" {
+		return nil, fmt.Errorf("VISUAL or EDITOR must be set to edit snippets")
+	}
+
+	tempDir, err := os.MkdirTemp("", "atlas-snippet-*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(tempDir)
+
+	tempPath := filepath.Join(tempDir, filepath.Base(filename))
+	if err := os.WriteFile(tempPath, content, 0o600); err != nil {
+		return nil, err
+	}
+
+	editorCmd := exec.Command("sh", "-c", editor+" \"$1\"", "atlas-editor", tempPath)
+	editorCmd.Stdin = os.Stdin
+	editorCmd.Stdout = os.Stdout
+	editorCmd.Stderr = os.Stderr
+	if err := editorCmd.Run(); err != nil {
+		return nil, err
+	}
+
+	edited, err := os.ReadFile(tempPath)
+	if err != nil {
+		return nil, err
+	}
+	if bytes.Equal(content, edited) {
+		return nil, errors.New("no changes made")
+	}
+	return edited, nil
+}
+
+func confirmSnippetDelete(id string) (bool, error) {
+	fmt.Fprintf(os.Stderr, "Delete snippet %s? [y/N] ", id)
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes", nil
 }

--- a/internal/cli/snippet.go
+++ b/internal/cli/snippet.go
@@ -345,6 +345,9 @@ func runSnippetEdit(cmd *cobra.Command, args []string) error {
 	if filename == "" && len(args) == 2 {
 		filename = args[1]
 	}
+	if filename != "" && title != "" && addFile == "" && removeFile == "" {
+		return fmt.Errorf("filename cannot be used with --title unless editing file contents or adding a file")
+	}
 
 	client, err := bitbucket.NewClient(bitbucket.WithNoCache(noCache))
 	if err != nil {
@@ -359,7 +362,13 @@ func runSnippetEdit(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to read file %s: %w", addFile, err)
 		}
-		addFiles[snippetLocalFilename(addFile)] = content
+		targetFilename := filename
+		if targetFilename == "" {
+			targetFilename = snippetLocalFilename(addFile)
+		}
+		if err := addSnippetFileContent(addFiles, targetFilename, content, addFile); err != nil {
+			return err
+		}
 	}
 
 	if removeFile != "" {
@@ -530,13 +539,14 @@ func parseSnippetRef(raw, fallbackWorkspace string) (snippetRef, error) {
 
 	parsed, err := url.Parse(raw)
 	if err == nil && parsed.Host != "" {
+		host := parsed.Hostname()
 		parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
 		switch {
-		case parsed.Host == "bitbucket.org" && len(parts) >= 3 && parts[0] == "snippets":
+		case host == "bitbucket.org" && len(parts) >= 3 && parts[0] == "snippets":
 			return snippetRefFromURLParts(parts[1], parts[2])
-		case parsed.Host == "bitbucket.org" && len(parts) >= 4 && parts[1] == "workspace" && parts[2] == "snippets":
+		case host == "bitbucket.org" && len(parts) >= 4 && parts[1] == "workspace" && parts[2] == "snippets":
 			return snippetRefFromURLParts(parts[0], parts[3])
-		case strings.HasSuffix(parsed.Host, "bitbucket.org") && len(parts) >= 4 && parts[0] == "2.0" && parts[1] == "snippets":
+		case isBitbucketHost(host) && len(parts) >= 4 && parts[0] == "2.0" && parts[1] == "snippets":
 			return snippetRefFromURLParts(parts[2], parts[3])
 		default:
 			return snippetRef{}, fmt.Errorf("unsupported snippet URL: %s", raw)
@@ -547,6 +557,10 @@ func parseSnippetRef(raw, fallbackWorkspace string) (snippetRef, error) {
 		return snippetRef{}, fmt.Errorf("workspace not configured. Run 'atlas config set workspace <name>' or use --workspace")
 	}
 	return snippetRef{Workspace: fallbackWorkspace, ID: raw}, nil
+}
+
+func isBitbucketHost(host string) bool {
+	return host == "bitbucket.org" || strings.HasSuffix(host, ".bitbucket.org")
 }
 
 func snippetRefFromURLParts(workspacePart, idPart string) (snippetRef, error) {
@@ -632,7 +646,10 @@ func readSnippetCreateFiles(args []string, stdinFilename string) (map[string][]b
 		if err != nil {
 			return nil, fmt.Errorf("failed to read file %s: %w", arg, err)
 		}
-		files[snippetLocalFilename(arg)] = content
+		filename := snippetLocalFilename(arg)
+		if err := addSnippetFileContent(files, filename, content, arg); err != nil {
+			return nil, err
+		}
 	}
 
 	if len(args) == 0 && !term.IsTerminal(int(os.Stdin.Fd())) {
@@ -647,13 +664,23 @@ func readSnippetCreateFiles(args []string, stdinFilename string) (map[string][]b
 		if err != nil {
 			return nil, fmt.Errorf("failed to read standard input: %w", err)
 		}
-		files[stdinFilename] = content
+		if err := addSnippetFileContent(files, stdinFilename, content, "standard input"); err != nil {
+			return nil, err
+		}
 	}
 
 	if len(files) == 0 {
 		return nil, fmt.Errorf("at least one filename or - is required")
 	}
 	return files, nil
+}
+
+func addSnippetFileContent(files map[string][]byte, filename string, content []byte, source string) error {
+	if _, exists := files[filename]; exists {
+		return fmt.Errorf("duplicate snippet filename %q from %s", filename, source)
+	}
+	files[filename] = content
+	return nil
 }
 
 func snippetLocalFilename(filePath string) string {

--- a/internal/cli/snippet_test.go
+++ b/internal/cli/snippet_test.go
@@ -1,0 +1,197 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kabilan108/atlas/internal/bitbucket"
+)
+
+func TestParseSnippetRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		raw               string
+		fallbackWorkspace string
+		want              snippetRef
+	}{
+		{
+			name:              "id with fallback workspace",
+			raw:               "abc123",
+			fallbackWorkspace: "team",
+			want:              snippetRef{Workspace: "team", ID: "abc123"},
+		},
+		{
+			name: "html url",
+			raw:  "https://bitbucket.org/snippets/team/abc123/example-title",
+			want: snippetRef{Workspace: "team", ID: "abc123"},
+		},
+		{
+			name: "workspace web url",
+			raw:  "https://bitbucket.org/moberg-analytics/workspace/snippets/rqMxyL",
+			want: snippetRef{Workspace: "moberg-analytics", ID: "rqMxyL"},
+		},
+		{
+			name: "api url",
+			raw:  "https://api.bitbucket.org/2.0/snippets/team/abc123",
+			want: snippetRef{Workspace: "team", ID: "abc123"},
+		},
+		{
+			name: "clone url trims git suffix",
+			raw:  "https://bitbucket.org/snippets/team/abc123.git",
+			want: snippetRef{Workspace: "team", ID: "abc123"},
+		},
+		{
+			name: "encoded url parts are unescaped",
+			raw:  "https://bitbucket.org/snippets/team%20space/abc%20123",
+			want: snippetRef{Workspace: "team space", ID: "abc 123"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseSnippetRef(tt.raw, tt.fallbackWorkspace)
+			if err != nil {
+				t.Fatalf("parseSnippetRef() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseSnippetRef() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSnippetRefRequiresWorkspaceForID(t *testing.T) {
+	t.Parallel()
+
+	if _, err := parseSnippetRef("abc123", ""); err == nil {
+		t.Fatal("parseSnippetRef() error = nil, want workspace error")
+	}
+}
+
+func TestParseSnippetRefRejectsUnsupportedURL(t *testing.T) {
+	t.Parallel()
+
+	if _, err := parseSnippetRef("https://example.com/snippets/team/abc123", "team"); err == nil {
+		t.Fatal("parseSnippetRef() error = nil, want unsupported URL error")
+	}
+}
+
+func TestSnippetCloneURL(t *testing.T) {
+	t.Parallel()
+
+	ref := snippetRef{Workspace: "team", ID: "abc123"}
+
+	tests := []struct {
+		protocol string
+		want     string
+	}{
+		{
+			protocol: "ssh",
+			want:     "git@bitbucket.org:snippets/team/abc123.git",
+		},
+		{
+			protocol: "https",
+			want:     "https://bitbucket.org/snippets/team/abc123.git",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.protocol, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := snippetCloneURL(ref, tt.protocol)
+			if err != nil {
+				t.Fatalf("snippetCloneURL() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("snippetCloneURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSnippetCloneURLRejectsInvalidProtocol(t *testing.T) {
+	t.Parallel()
+
+	_, err := snippetCloneURL(snippetRef{Workspace: "team", ID: "abc123"}, "ftp")
+	if err == nil {
+		t.Fatal("snippetCloneURL() error = nil, want invalid protocol error")
+	}
+}
+
+func TestSnippetLocalFilename(t *testing.T) {
+	t.Parallel()
+
+	if got := snippetLocalFilename("src/auth.go"); got != "src/auth.go" {
+		t.Fatalf("snippetLocalFilename() = %q, want %q", got, "src/auth.go")
+	}
+}
+
+func TestLimitSnippetsAfterVisibilityFiltering(t *testing.T) {
+	t.Parallel()
+
+	snippets := []bitbucket.Snippet{
+		{ID: "1", IsPrivate: false},
+		{ID: "2", IsPrivate: true},
+		{ID: "3", IsPrivate: true},
+		{ID: "4", IsPrivate: true},
+	}
+
+	filtered := filterSnippetsByVisibility(snippets, false, true)
+	got := limitSnippets(filtered, 2)
+
+	if len(got) != 2 || got[0].ID != "2" || got[1].ID != "3" {
+		t.Fatalf("filtered limited snippets = %#v, want IDs 2 and 3", got)
+	}
+}
+
+func TestSanitizeTerminalContent(t *testing.T) {
+	t.Parallel()
+
+	got := sanitizeTerminalContent("ok\x1b[31m\n\t")
+	want := "ok\\x1b[31m\n\t"
+	if got != want {
+		t.Fatalf("sanitizeTerminalContent() = %q, want %q", got, want)
+	}
+}
+
+func TestRequireSnippetFileRejectsMissingFile(t *testing.T) {
+	t.Parallel()
+
+	snippet := &bitbucket.Snippet{
+		Files: map[string]bitbucket.SnippetFile{
+			"exists.go": {},
+		},
+	}
+
+	if err := requireSnippetFile(snippet, "abc123", "typo.go"); err == nil {
+		t.Fatal("requireSnippetFile() error = nil, want missing file error")
+	}
+}
+
+func TestEditBufferSupportsQuotedEditorCommand(t *testing.T) {
+	tempDir := t.TempDir()
+	scriptPath := filepath.Join(tempDir, "edit script.sh")
+	script := "#!/bin/sh\nprintf changed > \"$1\"\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o700); err != nil {
+		t.Fatalf("failed to write editor script: %v", err)
+	}
+
+	t.Setenv("VISUAL", "'"+scriptPath+"'")
+	t.Setenv("EDITOR", "")
+
+	got, err := editBuffer("snippet.txt", []byte("original"))
+	if err != nil {
+		t.Fatalf("editBuffer() error = %v", err)
+	}
+	if string(got) != "changed" {
+		t.Fatalf("editBuffer() = %q, want %q", got, "changed")
+	}
+}

--- a/internal/cli/snippet_test.go
+++ b/internal/cli/snippet_test.go
@@ -82,6 +82,14 @@ func TestParseSnippetRefRejectsUnsupportedURL(t *testing.T) {
 	}
 }
 
+func TestParseSnippetRefRejectsSuffixSpoofedHost(t *testing.T) {
+	t.Parallel()
+
+	if _, err := parseSnippetRef("https://evilbitbucket.org/2.0/snippets/team/abc123", "team"); err == nil {
+		t.Fatal("parseSnippetRef() error = nil, want unsupported URL error")
+	}
+}
+
 func TestSnippetCloneURL(t *testing.T) {
 	t.Parallel()
 
@@ -131,6 +139,19 @@ func TestSnippetLocalFilename(t *testing.T) {
 
 	if got := snippetLocalFilename("src/auth.go"); got != "src/auth.go" {
 		t.Fatalf("snippetLocalFilename() = %q, want %q", got, "src/auth.go")
+	}
+}
+
+func TestAddSnippetFileContentRejectsDuplicates(t *testing.T) {
+	t.Parallel()
+
+	files := map[string][]byte{"same.txt": []byte("first")}
+	err := addSnippetFileContent(files, "same.txt", []byte("second"), "second source")
+	if err == nil {
+		t.Fatal("addSnippetFileContent() error = nil, want duplicate filename error")
+	}
+	if string(files["same.txt"]) != "first" {
+		t.Fatalf("duplicate write changed existing content to %q", files["same.txt"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Expanded `atlas snippet` into a fuller command set with `list`, `view`, `create`, `edit`, `rename`, `clone`, and `delete` flows.
- Added snippet URL parsing, workspace-aware resolution, interactive selection, and safer file path handling in the Bitbucket client.
- Improved snippet listing and viewing with visibility filters, limits, raw/file-only output, JSON support, and pager/browser integration.
- Updated docs and specs to reflect the new positional file input and snippet workflow.
- Added tests for snippet path encoding, list query generation, and CLI snippet behavior.

## Testing
- `go test ./internal/bitbucket`
- `go test ./internal/cli`
- Not run: full repository test suite
- Not run: manual CLI/browser verification for `snippet view --web` and interactive `snippet edit`/`snippet delete` flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded snippet commands: clone, rename, and enhanced list, view, create, edit, delete with richer flags and behaviors.
  * Positional file arguments for create (supports stdin), clone protocol selection, and improved output options (--json, --web, --raw).

* **Documentation**
  * Updated CLI docs and README usage examples to match revised snippet command syntax and options.

* **Tests**
  * Added unit tests covering CLI helpers, path handling, filtering, and editor/IO behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kabilan108/atlas/pull/3?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->