### PR TITLE
Add PR comment and review actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Create a Bitbucket API token at **Personal settings → App passwords** with sco
 | `read:user:bitbucket` | Yes |
 | `read:repository:bitbucket` | Yes |
 | `read:pullrequest:bitbucket` | Yes |
+| `write:pullrequest:bitbucket` | For posting comments, approvals, and change requests |
 | `read:snippet:bitbucket` | For snippets |
 | `write:snippet:bitbucket` | For snippets |
 | `delete:snippet:bitbucket` | For snippets |
@@ -78,6 +79,12 @@ atlas pr view --comments              # current branch PR
 atlas pr view --raw                   # raw markdown, no pager
 atlas pr diff -s                      # difftastic when available, delta fallback
 atlas pr edit --title "Fix auth flow" # opens body in $EDITOR/nvim when no body flag is passed
+atlas pr comment 123 --body "Looks good overall"
+atlas pr comment 123 --path internal/cli/pr.go --line 42 --body "Can this be simplified?"
+atlas pr comment 123 --reply-to 456 --body "Fixed in the latest push"
+atlas pr approve 123 --body "Reviewed locally"
+atlas pr request-changes 123 --body-file review.md
+atlas pr review 123 --request-changes --comment-spec comments.json --body "Please address these before merge"
 
 # Checkout PR branch locally
 atlas pr checkout 123

--- a/SPEC.md
+++ b/SPEC.md
@@ -59,6 +59,12 @@ atlas pr view [<id|url|branch>] [-R <workspace/repo|repo>] [--comments] [--all] 
 atlas pr diff [<id|url|branch>] [-R <workspace/repo|repo>] [--name-only] [--patch] [-s|--structured]
 atlas pr edit [<id|url|branch>] [-R <workspace/repo|repo>] [--title <title>] [--body <body>|--body-file <file>] [--add-reviewer <id>] [--remove-reviewer <id>]
 atlas pr close <id|url|branch> [-R <workspace/repo|repo>] [--comment <text>]
+atlas pr comment [<id|url|branch>] [-R <workspace/repo|repo>] (--body <text>|--body-file <file>|--editor) [--reply-to <id>] [--path <path>] [--line <line>] [--side new|old] [--json]
+atlas pr approve [<id|url|branch>] [-R <workspace/repo|repo>] [--body <text>|--body-file <file>|--editor] [--json]
+atlas pr unapprove [<id|url|branch>] [-R <workspace/repo|repo>] [--json]
+atlas pr request-changes [<id|url|branch>] [-R <workspace/repo|repo>] [--body <text>|--body-file <file>|--editor] [--json]
+atlas pr clear-change-request [<id|url|branch>] [-R <workspace/repo|repo>] [--json]
+atlas pr review [<id|url|branch>] [-R <workspace/repo|repo>] (--approve|--request-changes|--comment) [--body <text>|--body-file <file>|--editor] [--comment-spec <file>] [--json]
 atlas pr checkout <id|url|branch> [-R <workspace/repo|repo>] [--branch <name>] [--detach] [--force] [--recurse-submodules]
 atlas snippet list [--workspace <workspace>] [--role <role>] [--public|--private] [-L <limit>] [--json]
 atlas snippet view [<id|url>] [--filename <file>] [--files] [--raw] [--web] [--json]
@@ -312,6 +318,35 @@ Status only (no attribution for who completed).
 
 ---
 
+## PR Comments And Review Actions
+
+`atlas pr comment` creates a Bitbucket pull request comment.
+
+- Requires exactly one body source: `--body`, `--body-file`, or `--editor`
+- No selector means the current branch PR
+- `--reply-to <id>` posts a reply to an existing comment
+- `--path <path>` posts a file-level comment
+- `--path <path> --line <line> --side new|old` posts an inline comment
+- `--side new` maps to Bitbucket `inline.to`; `--side old` maps to `inline.from`
+- `--json` emits the created comment
+
+`atlas pr approve` and `atlas pr request-changes` update the authenticated user's review state.
+
+- Optional body flags post a top-level PR comment before the review action
+- If the comment succeeds but the review action fails, Atlas reports that partial success
+- `atlas pr unapprove` withdraws the authenticated user's approval
+- `atlas pr clear-change-request` withdraws the authenticated user's change request
+
+`atlas pr review` posts zero or more comments and then finishes with one action.
+
+- Exactly one of `--approve`, `--request-changes`, or `--comment` is required
+- `--comment-spec <file>` accepts a JSON array of `{ "body", "reply_to", "path", "line", "side" }` objects
+- Comments are posted in file order before the final action
+- If a comment fails, Atlas stops before changing review state
+- If the final action fails, Atlas reports how many comments were already posted
+
+---
+
 ## PR Status
 
 `atlas pr status` shows gh-like groups for the selected repository:
@@ -478,6 +513,11 @@ Retry with backoff based on `--retry` flag, then fail with actionable suggestion
 - `GET /repositories/{workspace}/{repo}/pullrequests` - list PRs
 - `GET /repositories/{workspace}/{repo}/pullrequests/{id}` - PR details
 - `GET /repositories/{workspace}/{repo}/pullrequests/{id}/comments` - PR comments
+- `POST /repositories/{workspace}/{repo}/pullrequests/{id}/comments` - create PR comments and replies
+- `POST /repositories/{workspace}/{repo}/pullrequests/{id}/approve` - approve a PR
+- `DELETE /repositories/{workspace}/{repo}/pullrequests/{id}/approve` - withdraw approval
+- `POST /repositories/{workspace}/{repo}/pullrequests/{id}/request-changes` - request changes
+- `DELETE /repositories/{workspace}/{repo}/pullrequests/{id}/request-changes` - withdraw change request
 - `GET /repositories/{workspace}/{repo}/pullrequests/{id}/diff` - PR diff
 - `GET /repositories/{workspace}/{repo}/src/{commit}/{path}` - file contents
 - `GET /user` - auth verification
@@ -570,6 +610,7 @@ Retry with backoff based on `--retry` flag, then fail with actionable suggestion
 **Deliverables**:
 - `atlas pr view 123 --json` outputs complete PR data
 - `atlas pr list --json` outputs PR list as JSON array
+- PR comment and review write commands expose returned API objects with `--json`
 - All-or-nothing output (no field selection)
 
 **Testable outcome**: Output can be piped to `jq` for processing.

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
         pkgs:
         pkgs.buildGoModule rec {
           pname = "atlas";
-          version = "0.0.6";
+          version = "0.0.7";
           src = self;
           vendorHash = "sha256-gEMzw1zfgXLlfwkSydNbZ8b4A/6FanI8tsdhSu3vhmE=";
 

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -15,10 +15,11 @@ import (
 	"github.com/kabilan108/atlas/internal/config"
 )
 
-const baseURL = "https://api.bitbucket.org/2.0"
+const defaultBaseURL = "https://api.bitbucket.org/2.0"
 
 type Client struct {
 	httpClient *http.Client
+	baseURL    string
 	username   string
 	password   string
 	cache      *Cache
@@ -57,6 +58,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 
 	c := &Client{
 		httpClient: &http.Client{Timeout: 30 * time.Second},
+		baseURL:    defaultBaseURL,
 		username:   cfg.Username,
 		password:   cfg.AppPassword,
 		cache:      cache,
@@ -67,6 +69,16 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	}
 
 	return c, nil
+}
+
+func newClientForTest(baseURL string, httpClient *http.Client) *Client {
+	return &Client{
+		httpClient: httpClient,
+		baseURL:    baseURL,
+		username:   "user",
+		password:   "password",
+		noCache:    true,
+	}
 }
 
 func (c *Client) do(req *http.Request) (*http.Response, error) {
@@ -93,15 +105,15 @@ func (c *Client) do(req *http.Request) (*http.Response, error) {
 }
 
 func (c *Client) get(path string) ([]byte, error) {
-	url := baseURL + path
+	requestURL := c.baseURL + path
 
 	if !c.noCache {
-		if data, ok := c.cache.Get(url); ok {
+		if data, ok := c.cache.Get(requestURL); ok {
 			return data, nil
 		}
 	}
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -122,16 +134,16 @@ func (c *Client) get(path string) ([]byte, error) {
 	}
 
 	if !c.noCache {
-		c.cache.Set(url, body)
+		c.cache.Set(requestURL, body)
 	}
 
 	return body, nil
 }
 
 func (c *Client) getRaw(path string) ([]byte, error) {
-	url := baseURL + path
+	requestURL := c.baseURL + path
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -164,6 +176,10 @@ func (c *Client) put(path string, body any) ([]byte, error) {
 	return c.sendJSON(http.MethodPut, path, body)
 }
 
+func (c *Client) delete(path string) ([]byte, error) {
+	return c.sendJSON(http.MethodDelete, path, nil)
+}
+
 func (c *Client) sendJSON(method, path string, body any) ([]byte, error) {
 	var payload io.Reader
 	if body != nil {
@@ -174,7 +190,7 @@ func (c *Client) sendJSON(method, path string, body any) ([]byte, error) {
 		payload = bytes.NewReader(data)
 	}
 
-	req, err := http.NewRequest(method, baseURL+path, payload)
+	req, err := http.NewRequest(method, c.baseURL+path, payload)
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +307,7 @@ func (c *Client) ListRepositories(workspace string) ([]Repository, error) {
 		}
 
 		repos = append(repos, page.Values...)
-		path = extractNextPath(page.Next)
+		path = c.extractNextPath(page.Next)
 	}
 
 	return repos, nil
@@ -346,7 +362,7 @@ func (c *Client) ListPullRequests(workspace, repo string, opts *PRListOptions) (
 			}
 			prs = append(prs, pr)
 		}
-		path = extractNextPath(page.Next)
+		path = c.extractNextPath(page.Next)
 	}
 
 	return prs, nil
@@ -490,18 +506,15 @@ func (c *Client) ListPullRequestComments(workspace, repo string, id int) ([]Comm
 		}
 
 		comments = append(comments, page.Values...)
-		path = extractNextPath(page.Next)
+		path = c.extractNextPath(page.Next)
 	}
 
 	return comments, nil
 }
 
-func (c *Client) CreatePullRequestComment(workspace, repo string, id int, body string) (*Comment, error) {
+func (c *Client) CreatePullRequestComment(workspace, repo string, id int, input CommentCreate) (*Comment, error) {
 	path := fmt.Sprintf("/repositories/%s/%s/pullrequests/%d/comments", workspace, repo, id)
-	payload := map[string]any{
-		"content": map[string]string{"raw": body},
-	}
-	data, err := c.post(path, payload)
+	data, err := c.post(path, input)
 	if err != nil {
 		return nil, err
 	}
@@ -512,6 +525,54 @@ func (c *Client) CreatePullRequestComment(workspace, repo string, id int, body s
 	}
 
 	return &comment, nil
+}
+
+func (c *Client) CreatePullRequestCommentText(workspace, repo string, id int, body string) (*Comment, error) {
+	return c.CreatePullRequestComment(workspace, repo, id, CommentCreate{
+		Content: ContentInput{Raw: body},
+	})
+}
+
+func (c *Client) ApprovePullRequest(workspace, repo string, id int) (*ReviewActionResult, error) {
+	path := fmt.Sprintf("/repositories/%s/%s/pullrequests/%d/approve", workspace, repo, id)
+	data, err := c.post(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result ReviewActionResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse approval response: %w", err)
+	}
+
+	return &result, nil
+}
+
+func (c *Client) UnapprovePullRequest(workspace, repo string, id int) error {
+	path := fmt.Sprintf("/repositories/%s/%s/pullrequests/%d/approve", workspace, repo, id)
+	_, err := c.delete(path)
+	return err
+}
+
+func (c *Client) RequestPullRequestChanges(workspace, repo string, id int) (*ReviewActionResult, error) {
+	path := fmt.Sprintf("/repositories/%s/%s/pullrequests/%d/request-changes", workspace, repo, id)
+	data, err := c.post(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result ReviewActionResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse request changes response: %w", err)
+	}
+
+	return &result, nil
+}
+
+func (c *Client) ClearPullRequestChanges(workspace, repo string, id int) error {
+	path := fmt.Sprintf("/repositories/%s/%s/pullrequests/%d/request-changes", workspace, repo, id)
+	_, err := c.delete(path)
+	return err
 }
 
 func (c *Client) GetPullRequestDiff(workspace, repo string, id int) ([]byte, error) {
@@ -538,18 +599,18 @@ func (c *Client) ListPullRequestTasks(workspace, repo string, id int) ([]Task, e
 		}
 
 		tasks = append(tasks, page.Values...)
-		path = extractNextPath(page.Next)
+		path = c.extractNextPath(page.Next)
 	}
 
 	return tasks, nil
 }
 
-func extractNextPath(nextURL string) string {
+func (c *Client) extractNextPath(nextURL string) string {
 	if nextURL == "" {
 		return ""
 	}
-	if len(nextURL) > len(baseURL) && nextURL[:len(baseURL)] == baseURL {
-		return nextURL[len(baseURL):]
+	if len(nextURL) > len(c.baseURL) && nextURL[:len(c.baseURL)] == c.baseURL {
+		return nextURL[len(c.baseURL):]
 	}
 	return ""
 }
@@ -621,7 +682,7 @@ func (c *Client) ListSnippets(workspace string, opts *SnippetListOptions) ([]Sni
 		if opts != nil && opts.Limit > 0 && len(snippets) >= opts.Limit {
 			return snippets[:opts.Limit], nil
 		}
-		path = extractNextPath(page.Next)
+		path = c.extractNextPath(page.Next)
 	}
 
 	return snippets, nil
@@ -652,7 +713,7 @@ func (c *Client) GetSnippetFileContent(workspace, id, filename string) ([]byte, 
 }
 
 func (c *Client) CreateSnippet(workspace, title string, files map[string][]byte, isPrivate bool) (*Snippet, error) {
-	url := baseURL + fmt.Sprintf("/snippets/%s", url.PathEscape(workspace))
+	requestURL := c.baseURL + fmt.Sprintf("/snippets/%s", url.PathEscape(workspace))
 
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
@@ -679,7 +740,7 @@ func (c *Client) CreateSnippet(workspace, title string, files map[string][]byte,
 		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, url, &buf)
+	req, err := http.NewRequest(http.MethodPost, requestURL, &buf)
 	if err != nil {
 		return nil, err
 	}
@@ -709,7 +770,7 @@ func (c *Client) CreateSnippet(workspace, title string, files map[string][]byte,
 }
 
 func (c *Client) UpdateSnippet(workspace, id, title string, addFiles map[string][]byte, removeFiles []string) error {
-	url := baseURL + fmt.Sprintf("/snippets/%s/%s", url.PathEscape(workspace), url.PathEscape(id))
+	requestURL := c.baseURL + fmt.Sprintf("/snippets/%s/%s", url.PathEscape(workspace), url.PathEscape(id))
 
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
@@ -740,7 +801,7 @@ func (c *Client) UpdateSnippet(workspace, id, title string, addFiles map[string]
 		return fmt.Errorf("failed to close multipart writer: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPut, url, &buf)
+	req, err := http.NewRequest(http.MethodPut, requestURL, &buf)
 	if err != nil {
 		return err
 	}
@@ -761,9 +822,9 @@ func (c *Client) UpdateSnippet(workspace, id, title string, addFiles map[string]
 }
 
 func (c *Client) DeleteSnippet(workspace, id string) error {
-	url := baseURL + fmt.Sprintf("/snippets/%s/%s", url.PathEscape(workspace), url.PathEscape(id))
+	requestURL := c.baseURL + fmt.Sprintf("/snippets/%s/%s", url.PathEscape(workspace), url.PathEscape(id))
 
-	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	req, err := http.NewRequest(http.MethodDelete, requestURL, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/bitbucket/client_test.go
+++ b/internal/bitbucket/client_test.go
@@ -1,6 +1,12 @@
 package bitbucket
 
-import "testing"
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
 func TestHasReviewerMatchesStableIdentifiersOnly(t *testing.T) {
 	t.Parallel()
@@ -36,4 +42,168 @@ func TestHasReviewerMatchesStableIdentifiersOnly(t *testing.T) {
 			t.Fatalf("hasReviewer(%q) = true, want false", reviewer)
 		}
 	}
+}
+
+func TestCreatePullRequestCommentSendsStructuredPayload(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input CommentCreate
+		check func(*testing.T, CommentCreate)
+	}{
+		{
+			name:  "top level",
+			input: CommentCreate{Content: ContentInput{Raw: "Looks good"}},
+			check: func(t *testing.T, got CommentCreate) {
+				t.Helper()
+				if got.Content.Raw != "Looks good" {
+					t.Fatalf("Content.Raw = %q, want Looks good", got.Content.Raw)
+				}
+				if got.Parent != nil || got.Inline != nil {
+					t.Fatalf("Parent = %#v Inline = %#v, want nil", got.Parent, got.Inline)
+				}
+			},
+		},
+		{
+			name:  "reply",
+			input: CommentCreate{Content: ContentInput{Raw: "Fixed"}, Parent: &ParentInput{ID: 44}},
+			check: func(t *testing.T, got CommentCreate) {
+				t.Helper()
+				if got.Parent == nil || got.Parent.ID != 44 {
+					t.Fatalf("Parent = %#v, want id 44", got.Parent)
+				}
+			},
+		},
+		{
+			name: "inline",
+			input: CommentCreate{
+				Content: ContentInput{Raw: "Question"},
+				Inline: &InlineInput{
+					Path: "internal/cli/pr.go",
+					To:   intPtr(12),
+				},
+			},
+			check: func(t *testing.T, got CommentCreate) {
+				t.Helper()
+				if got.Inline == nil || got.Inline.Path != "internal/cli/pr.go" {
+					t.Fatalf("Inline = %#v, want path", got.Inline)
+				}
+				if got.Inline.To == nil || *got.Inline.To != 12 {
+					t.Fatalf("Inline.To = %#v, want 12", got.Inline.To)
+				}
+				if got.Inline.From != nil {
+					t.Fatalf("Inline.From = %#v, want nil", got.Inline.From)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Fatalf("method = %s, want POST", r.Method)
+				}
+				if r.URL.Path != "/repositories/ws/repo/pullrequests/7/comments" {
+					t.Fatalf("path = %s, want comments endpoint", r.URL.Path)
+				}
+				if r.Header.Get("Content-Type") != "application/json" {
+					t.Fatalf("Content-Type = %q, want application/json", r.Header.Get("Content-Type"))
+				}
+				var got CommentCreate
+				if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+					t.Fatalf("Decode() error = %v", err)
+				}
+				tt.check(t, got)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"id":55,"content":{"raw":"created"}}`)
+			}))
+			defer server.Close()
+
+			client := newClientForTest(server.URL, server.Client())
+			comment, err := client.CreatePullRequestComment("ws", "repo", 7, tt.input)
+			if err != nil {
+				t.Fatalf("CreatePullRequestComment() error = %v", err)
+			}
+			if comment.ID != 55 {
+				t.Fatalf("comment.ID = %d, want 55", comment.ID)
+			}
+		})
+	}
+}
+
+func TestReviewActionEndpoints(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		call   func(*Client) error
+	}{
+		{
+			name:   "approve",
+			method: http.MethodPost,
+			path:   "/repositories/ws/repo/pullrequests/7/approve",
+			call: func(client *Client) error {
+				_, err := client.ApprovePullRequest("ws", "repo", 7)
+				return err
+			},
+		},
+		{
+			name:   "unapprove",
+			method: http.MethodDelete,
+			path:   "/repositories/ws/repo/pullrequests/7/approve",
+			call:   func(client *Client) error { return client.UnapprovePullRequest("ws", "repo", 7) },
+		},
+		{
+			name:   "request changes",
+			method: http.MethodPost,
+			path:   "/repositories/ws/repo/pullrequests/7/request-changes",
+			call: func(client *Client) error {
+				_, err := client.RequestPullRequestChanges("ws", "repo", 7)
+				return err
+			},
+		},
+		{
+			name:   "clear change request",
+			method: http.MethodDelete,
+			path:   "/repositories/ws/repo/pullrequests/7/request-changes",
+			call:   func(client *Client) error { return client.ClearPullRequestChanges("ws", "repo", 7) },
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != tt.method {
+					t.Fatalf("method = %s, want %s", r.Method, tt.method)
+				}
+				if r.URL.Path != tt.path {
+					t.Fatalf("path = %s, want %s", r.URL.Path, tt.path)
+				}
+				if tt.method == http.MethodDelete {
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"type":"participant","role":"REVIEWER","approved":true,"state":"approved"}`)
+			}))
+			defer server.Close()
+
+			client := newClientForTest(server.URL, server.Client())
+			if err := tt.call(client); err != nil {
+				t.Fatalf("call() error = %v", err)
+			}
+		})
+	}
+}
+
+func intPtr(value int) *int {
+	return &value
 }

--- a/internal/bitbucket/types.go
+++ b/internal/bitbucket/types.go
@@ -186,6 +186,12 @@ type Comment struct {
 	Links      Links       `json:"links"`
 }
 
+type CommentCreate struct {
+	Content ContentInput `json:"content"`
+	Inline  *InlineInput `json:"inline,omitempty"`
+	Parent  *ParentInput `json:"parent,omitempty"`
+}
+
 type Resolution struct {
 	User User      `json:"user"`
 	Date time.Time `json:"date"`
@@ -201,7 +207,17 @@ type Content struct {
 	HTML   string `json:"html"`
 }
 
+type ContentInput struct {
+	Raw string `json:"raw"`
+}
+
 type Inline struct {
+	Path string `json:"path"`
+	From *int   `json:"from,omitempty"`
+	To   *int   `json:"to,omitempty"`
+}
+
+type InlineInput struct {
 	Path string `json:"path"`
 	From *int   `json:"from,omitempty"`
 	To   *int   `json:"to,omitempty"`
@@ -209,6 +225,19 @@ type Inline struct {
 
 type Parent struct {
 	ID int `json:"id"`
+}
+
+type ParentInput struct {
+	ID int `json:"id"`
+}
+
+type ReviewActionResult struct {
+	Type           string    `json:"type"`
+	User           User      `json:"user"`
+	Role           string    `json:"role"`
+	Approved       bool      `json:"approved"`
+	State          string    `json:"state"`
+	ParticipatedOn time.Time `json:"participated_on"`
 }
 
 type PaginatedResponse[T any] struct {

--- a/internal/cli/pr.go
+++ b/internal/cli/pr.go
@@ -50,6 +50,12 @@ func newPRCmd() *cobra.Command {
 	cmd.AddCommand(newPRDiffCmd())
 	cmd.AddCommand(newPREditCmd())
 	cmd.AddCommand(newPRCloseCmd())
+	cmd.AddCommand(newPRCommentCmd())
+	cmd.AddCommand(newPRApproveCmd())
+	cmd.AddCommand(newPRUnapproveCmd())
+	cmd.AddCommand(newPRRequestChangesCmd())
+	cmd.AddCommand(newPRClearChangeRequestCmd())
+	cmd.AddCommand(newPRReviewCmd())
 	cmd.AddCommand(newPRCreateCmd())
 	cmd.AddCommand(newPRStatusCmd())
 
@@ -656,7 +662,7 @@ func runPRClose(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if comment != "" {
-		if _, err := ctx.client.CreatePullRequestComment(ctx.workspace, ctx.repo, pr.ID, comment); err != nil {
+		if _, err := ctx.client.CreatePullRequestCommentText(ctx.workspace, ctx.repo, pr.ID, comment); err != nil {
 			return err
 		}
 	}
@@ -668,6 +674,312 @@ func runPRClose(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	fmt.Printf("Closed pull request #%d: %s\n", closed.ID, closed.Title)
+	return nil
+}
+
+func newPRCommentCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "comment [number|url|branch]",
+		Short: "Comment on a pull request",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  runPRComment,
+	}
+	addPRRepoFlag(cmd)
+	addCommentBodyFlags(cmd)
+	cmd.Flags().Int("reply-to", 0, "Reply to an existing comment")
+	cmd.Flags().String("path", "", "Attach the comment to a file path")
+	cmd.Flags().Int("line", 0, "Attach the comment to a line in --path")
+	cmd.Flags().String("side", "new", "Line side for inline comments: new or old")
+	cmd.Flags().Bool("json", false, "Output as JSON")
+	return cmd
+}
+
+func runPRComment(cmd *cobra.Command, args []string) error {
+	body, _, err := readCommentBodyFromFlags(cmd, true)
+	if err != nil {
+		return err
+	}
+	replyTo, _ := cmd.Flags().GetInt("reply-to")
+	path, _ := cmd.Flags().GetString("path")
+	line, _ := cmd.Flags().GetInt("line")
+	side, _ := cmd.Flags().GetString("side")
+	if !cmd.Flags().Changed("side") && line == 0 {
+		side = ""
+	}
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+
+	input, err := buildCommentCreate(commentSpec{
+		Body:    body,
+		ReplyTo: replyTo,
+		Path:    path,
+		Line:    line,
+		Side:    side,
+	})
+	if err != nil {
+		return err
+	}
+
+	ctx, err := prCommandContext(cmd, false)
+	if err != nil {
+		return err
+	}
+	pr, err := resolvePR(ctx, optionalArg(args), true)
+	if err != nil {
+		return err
+	}
+	comment, err := ctx.client.CreatePullRequestComment(ctx.workspace, ctx.repo, pr.ID, input)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		return output.WriteJSON(os.Stdout, comment)
+	}
+	fmt.Printf("Created comment #%d on pull request #%d\n", comment.ID, pr.ID)
+	return nil
+}
+
+func newPRApproveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "approve [number|url|branch]",
+		Short: "Approve a pull request",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  runPRApprove,
+	}
+	addPRRepoFlag(cmd)
+	addCommentBodyFlags(cmd)
+	cmd.Flags().Bool("json", false, "Output as JSON")
+	return cmd
+}
+
+func runPRApprove(cmd *cobra.Command, args []string) error {
+	return runPRReviewAction(cmd, args, "approve")
+}
+
+func newPRUnapproveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unapprove [number|url|branch]",
+		Short: "Remove your approval from a pull request",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  runPRUnapprove,
+	}
+	addPRRepoFlag(cmd)
+	cmd.Flags().Bool("json", false, "Output as JSON")
+	return cmd
+}
+
+func runPRUnapprove(cmd *cobra.Command, args []string) error {
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	ctx, err := prCommandContext(cmd, false)
+	if err != nil {
+		return err
+	}
+	pr, err := resolvePR(ctx, optionalArg(args), true)
+	if err != nil {
+		return err
+	}
+	if err := ctx.client.UnapprovePullRequest(ctx.workspace, ctx.repo, pr.ID); err != nil {
+		return err
+	}
+	if jsonOutput {
+		return output.WriteJSON(os.Stdout, map[string]any{
+			"approved":     false,
+			"pull_request": pr.ID,
+		})
+	}
+	fmt.Printf("Removed approval from pull request #%d\n", pr.ID)
+	return nil
+}
+
+func newPRRequestChangesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "request-changes [number|url|branch]",
+		Short: "Request changes on a pull request",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  runPRRequestChanges,
+	}
+	addPRRepoFlag(cmd)
+	addCommentBodyFlags(cmd)
+	cmd.Flags().Bool("json", false, "Output as JSON")
+	return cmd
+}
+
+func runPRRequestChanges(cmd *cobra.Command, args []string) error {
+	return runPRReviewAction(cmd, args, "request-changes")
+}
+
+func newPRClearChangeRequestCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "clear-change-request [number|url|branch]",
+		Short: "Remove your change request from a pull request",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  runPRClearChangeRequest,
+	}
+	addPRRepoFlag(cmd)
+	cmd.Flags().Bool("json", false, "Output as JSON")
+	return cmd
+}
+
+func runPRClearChangeRequest(cmd *cobra.Command, args []string) error {
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	ctx, err := prCommandContext(cmd, false)
+	if err != nil {
+		return err
+	}
+	pr, err := resolvePR(ctx, optionalArg(args), true)
+	if err != nil {
+		return err
+	}
+	if err := ctx.client.ClearPullRequestChanges(ctx.workspace, ctx.repo, pr.ID); err != nil {
+		return err
+	}
+	if jsonOutput {
+		return output.WriteJSON(os.Stdout, map[string]any{
+			"changes_requested": false,
+			"pull_request":      pr.ID,
+		})
+	}
+	fmt.Printf("Removed change request from pull request #%d\n", pr.ID)
+	return nil
+}
+
+func newPRReviewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "review [number|url|branch]",
+		Short: "Post review comments and finish a pull request review",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  runPRReview,
+	}
+	addPRRepoFlag(cmd)
+	addCommentBodyFlags(cmd)
+	cmd.Flags().Bool("approve", false, "Finish by approving")
+	cmd.Flags().Bool("request-changes", false, "Finish by requesting changes")
+	cmd.Flags().Bool("comment", false, "Finish with comments only")
+	cmd.Flags().String("comment-spec", "", "JSON file of comments to post before the final review action")
+	cmd.Flags().Bool("json", false, "Output as JSON")
+	return cmd
+}
+
+type prReviewOutput struct {
+	PullRequest int                           `json:"pull_request"`
+	Action      string                        `json:"action"`
+	Comments    []bitbucket.Comment           `json:"comments,omitempty"`
+	Result      *bitbucket.ReviewActionResult `json:"result,omitempty"`
+}
+
+func runPRReview(cmd *cobra.Command, args []string) error {
+	action, err := reviewActionFromFlags(cmd)
+	if err != nil {
+		return err
+	}
+	body, hasSummary, err := readCommentBodyFromFlags(cmd, false)
+	if err != nil {
+		return err
+	}
+	specPath, _ := cmd.Flags().GetString("comment-spec")
+	specs, err := readCommentSpecs(specPath)
+	if err != nil {
+		return err
+	}
+	if action == "comment" && len(specs) == 0 && !hasSummary {
+		return fmt.Errorf("comment-only review requires --body, --body-file, --editor, or --comment-spec")
+	}
+
+	ctx, err := prCommandContext(cmd, false)
+	if err != nil {
+		return err
+	}
+	pr, err := resolvePR(ctx, optionalArg(args), true)
+	if err != nil {
+		return err
+	}
+
+	comments, err := postCommentSpecs(ctx, pr, specs)
+	if err != nil {
+		return err
+	}
+	if hasSummary {
+		comment, err := ctx.client.CreatePullRequestCommentText(ctx.workspace, ctx.repo, pr.ID, body)
+		if err != nil {
+			return fmt.Errorf("posted %d comments but failed to post review summary: %w", len(comments), err)
+		}
+		comments = append(comments, *comment)
+	}
+
+	var result *bitbucket.ReviewActionResult
+	switch action {
+	case "approve":
+		result, err = ctx.client.ApprovePullRequest(ctx.workspace, ctx.repo, pr.ID)
+	case "request-changes":
+		result, err = ctx.client.RequestPullRequestChanges(ctx.workspace, ctx.repo, pr.ID)
+	}
+	if err != nil {
+		return fmt.Errorf("posted %d comments but failed to %s pull request: %w", len(comments), reviewActionPhrase(action), err)
+	}
+
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	if jsonOutput {
+		return output.WriteJSON(os.Stdout, prReviewOutput{
+			PullRequest: pr.ID,
+			Action:      action,
+			Comments:    comments,
+			Result:      result,
+		})
+	}
+	switch action {
+	case "approve":
+		fmt.Printf("Posted %d comments and approved pull request #%d\n", len(comments), pr.ID)
+	case "request-changes":
+		fmt.Printf("Posted %d comments and requested changes on pull request #%d\n", len(comments), pr.ID)
+	default:
+		fmt.Printf("Posted %d comments on pull request #%d\n", len(comments), pr.ID)
+	}
+	return nil
+}
+
+func runPRReviewAction(cmd *cobra.Command, args []string, action string) error {
+	body, hasComment, err := readCommentBodyFromFlags(cmd, false)
+	if err != nil {
+		return err
+	}
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	ctx, err := prCommandContext(cmd, false)
+	if err != nil {
+		return err
+	}
+	pr, err := resolvePR(ctx, optionalArg(args), true)
+	if err != nil {
+		return err
+	}
+	if hasComment {
+		if _, err := ctx.client.CreatePullRequestCommentText(ctx.workspace, ctx.repo, pr.ID, body); err != nil {
+			return err
+		}
+	}
+
+	var result *bitbucket.ReviewActionResult
+	switch action {
+	case "approve":
+		result, err = ctx.client.ApprovePullRequest(ctx.workspace, ctx.repo, pr.ID)
+	case "request-changes":
+		result, err = ctx.client.RequestPullRequestChanges(ctx.workspace, ctx.repo, pr.ID)
+	default:
+		return fmt.Errorf("unknown review action %q", action)
+	}
+	if err != nil {
+		if hasComment {
+			return fmt.Errorf("posted comment but failed to %s pull request: %w", reviewActionPhrase(action), err)
+		}
+		return err
+	}
+	if jsonOutput {
+		return output.WriteJSON(os.Stdout, result)
+	}
+	switch action {
+	case "approve":
+		fmt.Printf("Approved pull request #%d\n", pr.ID)
+	case "request-changes":
+		fmt.Printf("Requested changes on pull request #%d\n", pr.ID)
+	}
 	return nil
 }
 
@@ -969,6 +1281,224 @@ func optionalArg(args []string) string {
 		return ""
 	}
 	return args[0]
+}
+
+type commentBodyFlags struct {
+	body        string
+	bodySet     bool
+	bodyFile    string
+	bodyFileSet bool
+	editor      bool
+}
+
+type commentSpec struct {
+	Body    string `json:"body"`
+	ReplyTo int    `json:"reply_to,omitempty"`
+	Path    string `json:"path,omitempty"`
+	Line    int    `json:"line,omitempty"`
+	Side    string `json:"side,omitempty"`
+}
+
+func addCommentBodyFlags(cmd *cobra.Command) {
+	cmd.Flags().StringP("body", "b", "", "Comment body")
+	cmd.Flags().StringP("body-file", "F", "", "Read comment body from file (use - to read from stdin)")
+	cmd.Flags().BoolP("editor", "e", false, "Open the editor to write the comment body")
+}
+
+func getCommentBodyFlags(cmd *cobra.Command) commentBodyFlags {
+	body, _ := cmd.Flags().GetString("body")
+	bodyFile, _ := cmd.Flags().GetString("body-file")
+	editor, _ := cmd.Flags().GetBool("editor")
+	return commentBodyFlags{
+		body:        body,
+		bodySet:     cmd.Flags().Changed("body"),
+		bodyFile:    bodyFile,
+		bodyFileSet: cmd.Flags().Changed("body-file"),
+		editor:      editor,
+	}
+}
+
+func validateCommentBodySources(flags commentBodyFlags, required bool) error {
+	count := 0
+	if flags.bodySet || flags.body != "" {
+		count++
+	}
+	if flags.bodyFileSet || flags.bodyFile != "" {
+		count++
+	}
+	if flags.editor {
+		count++
+	}
+	if count > 1 {
+		return fmt.Errorf("--body, --body-file, and --editor are mutually exclusive")
+	}
+	if required && count == 0 {
+		return fmt.Errorf("one of --body, --body-file, or --editor is required")
+	}
+	return nil
+}
+
+func readCommentBodyFromFlags(cmd *cobra.Command, required bool) (string, bool, error) {
+	flags := getCommentBodyFlags(cmd)
+	if err := validateCommentBodySources(flags, required); err != nil {
+		return "", false, err
+	}
+	hasBody := flags.bodySet || flags.body != "" || flags.bodyFileSet || flags.bodyFile != "" || flags.editor
+	if !hasBody {
+		return "", false, nil
+	}
+
+	var body string
+	switch {
+	case flags.bodySet || flags.body != "":
+		body = flags.body
+	case flags.bodyFileSet || flags.bodyFile != "":
+		bodyBytes, err := readBodyFile(flags.bodyFile)
+		if err != nil {
+			return "", false, err
+		}
+		body = string(bodyBytes)
+	case flags.editor:
+		edited, err := editTextInEditor("")
+		if err != nil {
+			return "", false, err
+		}
+		body = edited
+	}
+	if strings.TrimSpace(body) == "" {
+		return "", false, fmt.Errorf("comment body cannot be empty")
+	}
+	return body, true, nil
+}
+
+func buildCommentCreate(spec commentSpec) (bitbucket.CommentCreate, error) {
+	body := spec.Body
+	if strings.TrimSpace(body) == "" {
+		return bitbucket.CommentCreate{}, fmt.Errorf("comment body cannot be empty")
+	}
+	if spec.ReplyTo < 0 {
+		return bitbucket.CommentCreate{}, fmt.Errorf("--reply-to must be greater than zero")
+	}
+	if spec.Line < 0 {
+		return bitbucket.CommentCreate{}, fmt.Errorf("--line must be greater than zero")
+	}
+
+	path := strings.TrimSpace(spec.Path)
+	side := strings.ToLower(strings.TrimSpace(spec.Side))
+	if spec.ReplyTo > 0 {
+		if path != "" || spec.Line != 0 || side != "" {
+			return bitbucket.CommentCreate{}, fmt.Errorf("--reply-to cannot be combined with --path, --line, or --side")
+		}
+		return bitbucket.CommentCreate{
+			Content: bitbucket.ContentInput{Raw: body},
+			Parent:  &bitbucket.ParentInput{ID: spec.ReplyTo},
+		}, nil
+	}
+	if spec.Line > 0 && path == "" {
+		return bitbucket.CommentCreate{}, fmt.Errorf("--line requires --path")
+	}
+	if side != "" && path == "" {
+		return bitbucket.CommentCreate{}, fmt.Errorf("--side requires --path")
+	}
+	if side != "" && spec.Line == 0 {
+		return bitbucket.CommentCreate{}, fmt.Errorf("--side requires --line")
+	}
+
+	input := bitbucket.CommentCreate{Content: bitbucket.ContentInput{Raw: body}}
+	if path == "" {
+		return input, nil
+	}
+
+	inline := bitbucket.InlineInput{Path: path}
+	if spec.Line > 0 {
+		switch side {
+		case "", "new":
+			inline.To = &spec.Line
+		case "old":
+			inline.From = &spec.Line
+		default:
+			return bitbucket.CommentCreate{}, fmt.Errorf("invalid --side %q: expected new or old", spec.Side)
+		}
+	} else if side != "" && side != "new" && side != "old" {
+		return bitbucket.CommentCreate{}, fmt.Errorf("invalid --side %q: expected new or old", spec.Side)
+	}
+	input.Inline = &inline
+	return input, nil
+}
+
+func readCommentSpecs(path string) ([]commentSpec, error) {
+	if path == "" {
+		return nil, nil
+	}
+	data, err := readBodyFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var specs []commentSpec
+	if err := json.Unmarshal(data, &specs); err != nil {
+		return nil, fmt.Errorf("failed to parse comment spec: %w", err)
+	}
+	return specs, nil
+}
+
+func buildCommentCreates(specs []commentSpec) ([]bitbucket.CommentCreate, error) {
+	inputs := make([]bitbucket.CommentCreate, 0, len(specs))
+	for index, spec := range specs {
+		input, err := buildCommentCreate(spec)
+		if err != nil {
+			return nil, fmt.Errorf("invalid comment spec %d: %w", index+1, err)
+		}
+		inputs = append(inputs, input)
+	}
+	return inputs, nil
+}
+
+func postCommentSpecs(ctx *prContext, pr *bitbucket.PullRequest, specs []commentSpec) ([]bitbucket.Comment, error) {
+	inputs, err := buildCommentCreates(specs)
+	if err != nil {
+		return nil, err
+	}
+	comments := make([]bitbucket.Comment, 0, len(inputs))
+	for index, input := range inputs {
+		comment, err := ctx.client.CreatePullRequestComment(ctx.workspace, ctx.repo, pr.ID, input)
+		if err != nil {
+			return nil, fmt.Errorf("posted %d comments but failed to post comment %d: %w", len(comments), index+1, err)
+		}
+		comments = append(comments, *comment)
+	}
+	return comments, nil
+}
+
+func reviewActionFromFlags(cmd *cobra.Command) (string, error) {
+	approve, _ := cmd.Flags().GetBool("approve")
+	requestChanges, _ := cmd.Flags().GetBool("request-changes")
+	commentOnly, _ := cmd.Flags().GetBool("comment")
+
+	actions := []string{}
+	if approve {
+		actions = append(actions, "approve")
+	}
+	if requestChanges {
+		actions = append(actions, "request-changes")
+	}
+	if commentOnly {
+		actions = append(actions, "comment")
+	}
+	if len(actions) != 1 {
+		return "", fmt.Errorf("exactly one of --approve, --request-changes, or --comment is required")
+	}
+	return actions[0], nil
+}
+
+func reviewActionPhrase(action string) string {
+	switch action {
+	case "approve":
+		return "approve"
+	case "request-changes":
+		return "request changes on"
+	default:
+		return action
+	}
 }
 
 func readBodyFile(path string) ([]byte, error) {

--- a/internal/cli/pr_test.go
+++ b/internal/cli/pr_test.go
@@ -248,3 +248,218 @@ func TestReviewerSummary(t *testing.T) {
 		t.Fatalf("reviewerSummary() = %q, want %q", got, want)
 	}
 }
+
+func TestPRWriteCommandsRegistered(t *testing.T) {
+	t.Parallel()
+
+	cmd := newPRCmd()
+	for _, name := range []string{"comment", "approve", "unapprove", "request-changes", "clear-change-request", "review"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			found, _, err := cmd.Find([]string{name})
+			if err != nil {
+				t.Fatalf("Find(%q) error = %v", name, err)
+			}
+			if found.Name() != name {
+				t.Fatalf("Find(%q) = %q, want %q", name, found.Name(), name)
+			}
+		})
+	}
+}
+
+func TestBuildCommentCreate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		spec commentSpec
+		want func(*testing.T, bitbucket.CommentCreate)
+	}{
+		{
+			name: "top level",
+			spec: commentSpec{Body: "Looks good"},
+			want: func(t *testing.T, got bitbucket.CommentCreate) {
+				t.Helper()
+				if got.Content.Raw != "Looks good" {
+					t.Fatalf("Content.Raw = %q, want %q", got.Content.Raw, "Looks good")
+				}
+				if got.Parent != nil || got.Inline != nil {
+					t.Fatalf("Parent = %#v Inline = %#v, want nil", got.Parent, got.Inline)
+				}
+			},
+		},
+		{
+			name: "reply",
+			spec: commentSpec{Body: "Fixed", ReplyTo: 123},
+			want: func(t *testing.T, got bitbucket.CommentCreate) {
+				t.Helper()
+				if got.Parent == nil || got.Parent.ID != 123 {
+					t.Fatalf("Parent = %#v, want id 123", got.Parent)
+				}
+				if got.Inline != nil {
+					t.Fatalf("Inline = %#v, want nil", got.Inline)
+				}
+			},
+		},
+		{
+			name: "file level",
+			spec: commentSpec{Body: "Question", Path: "internal/cli/pr.go"},
+			want: func(t *testing.T, got bitbucket.CommentCreate) {
+				t.Helper()
+				if got.Inline == nil || got.Inline.Path != "internal/cli/pr.go" {
+					t.Fatalf("Inline = %#v, want path", got.Inline)
+				}
+				if got.Inline.From != nil || got.Inline.To != nil {
+					t.Fatalf("Inline = %#v, want no line", got.Inline)
+				}
+			},
+		},
+		{
+			name: "new line",
+			spec: commentSpec{Body: "Question", Path: "internal/cli/pr.go", Line: 42, Side: "new"},
+			want: func(t *testing.T, got bitbucket.CommentCreate) {
+				t.Helper()
+				if got.Inline == nil || got.Inline.To == nil || *got.Inline.To != 42 {
+					t.Fatalf("Inline = %#v, want to line 42", got.Inline)
+				}
+				if got.Inline.From != nil {
+					t.Fatalf("From = %#v, want nil", got.Inline.From)
+				}
+			},
+		},
+		{
+			name: "old line",
+			spec: commentSpec{Body: "Question", Path: "internal/cli/pr.go", Line: 42, Side: "old"},
+			want: func(t *testing.T, got bitbucket.CommentCreate) {
+				t.Helper()
+				if got.Inline == nil || got.Inline.From == nil || *got.Inline.From != 42 {
+					t.Fatalf("Inline = %#v, want from line 42", got.Inline)
+				}
+				if got.Inline.To != nil {
+					t.Fatalf("To = %#v, want nil", got.Inline.To)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := buildCommentCreate(tt.spec)
+			if err != nil {
+				t.Fatalf("buildCommentCreate() error = %v", err)
+			}
+			tt.want(t, got)
+		})
+	}
+}
+
+func TestBuildCommentCreateRejectsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		spec commentSpec
+	}{
+		{name: "empty body", spec: commentSpec{Body: "  "}},
+		{name: "line without path", spec: commentSpec{Body: "body", Line: 3}},
+		{name: "side without line", spec: commentSpec{Body: "body", Path: "file.go", Side: "old"}},
+		{name: "invalid side", spec: commentSpec{Body: "body", Path: "file.go", Line: 3, Side: "right"}},
+		{name: "reply with path", spec: commentSpec{Body: "body", ReplyTo: 1, Path: "file.go"}},
+		{name: "reply with line", spec: commentSpec{Body: "body", ReplyTo: 1, Line: 3}},
+		{name: "reply with side", spec: commentSpec{Body: "body", ReplyTo: 1, Side: "new"}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := buildCommentCreate(tt.spec); err == nil {
+				t.Fatal("buildCommentCreate() error = nil, want error")
+			}
+		})
+	}
+}
+
+func TestBuildCommentCreatesRejectsInvalidBatchBeforePosting(t *testing.T) {
+	t.Parallel()
+
+	specs := []commentSpec{
+		{Body: "first"},
+		{Body: "second", Path: "file.go", Side: "old"},
+	}
+
+	if _, err := buildCommentCreates(specs); err == nil {
+		t.Fatal("buildCommentCreates() error = nil, want error")
+	}
+}
+
+func TestValidateCommentBodySources(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		flags    commentBodyFlags
+		required bool
+		wantErr  bool
+	}{
+		{name: "required with body", flags: commentBodyFlags{body: "body"}, required: true},
+		{name: "required missing", required: true, wantErr: true},
+		{name: "optional missing", required: false},
+		{name: "body and file", flags: commentBodyFlags{body: "body", bodyFile: "body.md"}, required: true, wantErr: true},
+		{name: "body and editor", flags: commentBodyFlags{body: "body", editor: true}, required: true, wantErr: true},
+		{name: "file and editor", flags: commentBodyFlags{bodyFile: "body.md", editor: true}, required: true, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateCommentBodySources(tt.flags, tt.required)
+			if tt.wantErr && err == nil {
+				t.Fatal("validateCommentBodySources() error = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validateCommentBodySources() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestReviewActionFromFlags(t *testing.T) {
+	t.Parallel()
+
+	cmd := newPRReviewCmd()
+	if err := cmd.Flags().Set("approve", "true"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := reviewActionFromFlags(cmd)
+	if err != nil {
+		t.Fatalf("reviewActionFromFlags() error = %v", err)
+	}
+	if got != "approve" {
+		t.Fatalf("reviewActionFromFlags() = %q, want approve", got)
+	}
+}
+
+func TestReviewActionFromFlagsRejectsMissingOrMultiple(t *testing.T) {
+	t.Parallel()
+
+	missing := newPRReviewCmd()
+	if _, err := reviewActionFromFlags(missing); err == nil {
+		t.Fatal("reviewActionFromFlags() missing error = nil, want error")
+	}
+
+	multiple := newPRReviewCmd()
+	if err := multiple.Flags().Set("approve", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := multiple.Flags().Set("request-changes", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reviewActionFromFlags(multiple); err == nil {
+		t.Fatal("reviewActionFromFlags() multiple error = nil, want error")
+	}
+}


### PR DESCRIPTION
## Summary
- add Bitbucket Cloud PR comment, approve, unapprove, request-changes, and clear-change-request client support
- add `atlas pr comment`, `approve`, `unapprove`, `request-changes`, `clear-change-request`, and `review` commands
- validate comment specs before posting and document the new write scope

## Tests
- `CGO_ENABLED=0 go test ./...`
- `git diff --check`
- `CGO_ENABLED=0 go run ./cmd/atlas pr comment --help`
- `CGO_ENABLED=0 go run ./cmd/atlas pr review --help`

Fixes #4